### PR TITLE
FPGA Linear Feedback Shift Register

### DIFF
--- a/FPGA/lfsr/Makefile
+++ b/FPGA/lfsr/Makefile
@@ -1,0 +1,67 @@
+#----------------------------------------
+#-- Name of the component
+#----------------------------------------
+NAME = lfsr
+DEPS = 
+
+#-------------------------------------------------------
+#-- By default --> simulation and synthesis
+#-------------------------------------------------------
+all: sim sint
+
+#----------------------------------------------
+#-- make sim
+#----------------------------------------------
+#-- Make the simulation given by the test bench
+#----------------------------------------------
+sim: $(NAME)_tb.vcd
+
+#-----------------------------------------------
+#-  make sint
+#-----------------------------------------------
+#-  Make the synthesis for icestick FPGA
+#-----------------------------------------------
+sint: $(NAME).bin
+
+#-----------------------------------------------
+#-  make flash
+#-----------------------------------------------
+#-  Flash the icestick FPGA with the bitstream
+#-----------------------------------------------
+flash:
+	sudo iceprog $(NAME).bin
+
+#-------------------------------
+#-- Compilation and simulation
+#-------------------------------
+$(NAME)_tb.vcd: $(NAME).v $(NAME)_tb.v $(DEPS)
+
+	#-- Compilation
+	iverilog $^ -o $(NAME)_tb.out
+
+	#-- Simulation
+	./$(NAME)_tb.out
+
+	#-- To see the simulation in gtkwave
+	gtkwave $@ $(NAME)_tb.gtkw &
+
+#------------------------------
+#-- Complete synthesis
+#------------------------------
+$(NAME).bin: $(NAME).pcf $(NAME).v
+
+	#-- Synthesis
+	yosys -p "synth_ice40 -blif $(NAME).blif" $(NAME).v $(DEPS)
+
+	#-- Place & route
+	arachne-pnr -d 1k -p $(NAME).pcf $(NAME).blif -o $(NAME).txt
+
+	#-- Generate final bitstrem file
+	icepack $(NAME).txt $(NAME).bin
+
+
+#-- Limpiar todo
+clean:
+	rm -f *.bin *.txt *.blif *.out *.vcd *~
+
+.PHONY: all clean

--- a/FPGA/lfsr/lfsr.v
+++ b/FPGA/lfsr/lfsr.v
@@ -1,0 +1,48 @@
+`default_nettype none
+
+module lfsr (
+  input wire clk_96MHz,
+  input wire [16:0] polynomial,
+  input wire [16:0] start_data,
+  input wire enable,
+
+  output reg [16:0] value,
+  output reg [16:0] iteration_number
+  );
+
+localparam  IDLE = 0;
+localparam  LOAD = 1;
+localparam  ITERATE = 2;
+
+reg [1:0] state = IDLE;
+reg binary_bit;
+
+always @ (posedge clk_96MHz) begin
+  case (state)
+    IDLE: begin
+      if (enable == 1) begin
+        state <= LOAD;
+      end
+    end
+
+    LOAD: begin
+      value <= start_data;
+      iteration_number <= 0;
+      state <= ITERATE;
+    end
+
+    ITERATE: begin
+      if (enable == 1) begin
+        value <= {value, ^(value & polynomial)};
+        iteration_number <= iteration_number + 1;
+      end else begin
+        state <= IDLE;
+      end
+    end
+
+    default: ;
+  endcase
+
+end
+
+endmodule // lfsr

--- a/FPGA/lfsr/lfsr_tb.v
+++ b/FPGA/lfsr/lfsr_tb.v
@@ -1,0 +1,30 @@
+module lfsr_tb ();
+
+reg clk = 0;
+reg enable = 0;
+reg [16:0] polynomial = 17'h1d258;
+reg [16:0] start_data = 1;
+wire [16:0] value;
+wire [16:0] iteration_number;
+
+lfsr dut(
+  .clk_96MHz (clk),
+  .polynomial (polynomial),
+  .start_data (start_data),
+  .enable (enable),
+  .value (value),
+  .iteration_number (iteration_number)
+  );
+
+always #1 clk <= ~clk;
+
+initial begin
+  $dumpfile("lfsr_tb.vcd");
+  $dumpvars(0, lfsr_tb);
+
+  #0 $display("start of simulation");
+  #5 enable <= 1;
+  #15000 $finish;
+end
+
+endmodule // lfsr_tb

--- a/lfsr/test.py
+++ b/lfsr/test.py
@@ -1,0 +1,6 @@
+from lfsr import LFSR
+
+lfsr = LFSR(0x1D258, 1)
+
+for _ in range(65789):
+    print(hex(lfsr.next()))


### PR DESCRIPTION
# Purpose of this PR

Just to include a Linear Feedback Shift Register (LFSR) module into the code base that can be used by the future polynomial_identifier and offset_finder.

# What's happening in the module

*4 inputs:*
- clock (wire 1 bit)
- polynomial to use (wire 17 bits)
- start_data (wire 17 bits)
- enable (wire 1 bit)

*2 outputs:*
- value (reg 17 bits)
- iteration_number (reg 17 bits)

While enable is set to logical level 1, the module will load the start data into value and set iteration_number to 0. Then it will run the LFSR until it gets deactivated (enable set to logical level 0). At each clock positive edge, the LFSR module will iterate. 

`value <= {value, ^(value & polynomial)};` means that value will take this value: 
```
value[16:1] = value << 1;
value[0] = XOR ( value & polynomial )
```
This is how is computed a next Linear Feedback Shift Register state.