### PR TITLE
FPGA polynomial_finder

### DIFF
--- a/FPGA/polynomial_finder/Makefile
+++ b/FPGA/polynomial_finder/Makefile
@@ -1,0 +1,67 @@
+#----------------------------------------
+#-- Name of the component
+#----------------------------------------
+NAME = polynomial_finder
+DEPS = ../lfsr/lfsr.v
+
+#-------------------------------------------------------
+#-- By default --> simulation and synthesis
+#-------------------------------------------------------
+all: sim sint
+
+#----------------------------------------------
+#-- make sim
+#----------------------------------------------
+#-- Make the simulation given by the test bench
+#----------------------------------------------
+sim: $(NAME)_tb.vcd
+
+#-----------------------------------------------
+#-  make sint
+#-----------------------------------------------
+#-  Make the synthesis for icestick FPGA
+#-----------------------------------------------
+sint: $(NAME).bin
+
+#-----------------------------------------------
+#-  make flash
+#-----------------------------------------------
+#-  Flash the icestick FPGA with the bitstream
+#-----------------------------------------------
+flash:
+	sudo iceprog $(NAME).bin
+
+#-------------------------------
+#-- Compilation and simulation
+#-------------------------------
+$(NAME)_tb.vcd: $(NAME).v $(NAME)_tb.v $(DEPS)
+
+	#-- Compilation
+	iverilog $^ -o $(NAME)_tb.out
+
+	#-- Simulation
+	./$(NAME)_tb.out
+
+	#-- To see the simulation in gtkwave
+	gtkwave $@ $(NAME)_tb.gtkw &
+
+#------------------------------
+#-- Complete synthesis
+#------------------------------
+$(NAME).bin: $(NAME).pcf $(NAME).v
+
+	#-- Synthesis
+	yosys -p "synth_ice40 -blif $(NAME).blif" $(NAME).v $(DEPS)
+
+	#-- Place & route
+	arachne-pnr -d 1k -p $(NAME).pcf $(NAME).blif -o $(NAME).txt
+
+	#-- Generate final bitstrem file
+	icepack $(NAME).txt $(NAME).bin
+
+
+#-- Limpiar todo
+clean:
+	rm -f *.bin *.txt *.blif *.out *.vcd *~
+
+.PHONY: all clean

--- a/FPGA/polynomial_finder/polynomial_finder.v
+++ b/FPGA/polynomial_finder/polynomial_finder.v
@@ -1,0 +1,109 @@
+`default_nettype none
+
+module polynomial_finder (
+  input wire clk_96MHz,
+  input wire [23:0] ts_last_data,
+  input wire [23:0] ts_last_data1,
+  input wire [16:0] decoded_data,
+  input wire [16:0] decoded_data1,
+  input wire enable,
+
+  output reg [16:0] polynomial,
+  output reg [16:0] iteration_number,
+  output reg ready
+  );
+
+parameter iteration_approx = 3;
+
+localparam  IDLE = 0;
+localparam  ESTIMATE_ITERATION = 1;
+localparam  RUN_LFSR = 2;
+localparam  IDENTIFY_POLYNOMIAL = 3;
+localparam  WAIT_FOR_RESET = 4;
+
+reg [2:0] state = IDLE;
+
+reg enable_LFSRs = 0;
+
+wire [16:0] value_1D258, value_17E04;
+wire [16:0] iteration_number_1D258, iteration_number_17E04;
+
+lfsr lfsr1(
+  .clk_96MHz (clk_96MHz),
+  .polynomial (17'h1d258),
+  .start_data (decoded_data),
+  .enable (enable_LFSRs),
+  .value (value_1D258),
+  .iteration_number (iteration_number_1D258)
+  );
+
+lfsr lfsr2(
+  .clk_96MHz (clk_96MHz),
+  .polynomial (17'h17e04),
+  .start_data (decoded_data),
+  .enable (enable_LFSRs),
+  .value (value_17E04),
+  .iteration_number (iteration_number_17E04)
+  );
+
+reg [16:0] estimated_iteration; //17 bits is for security but it's way to much
+
+always @ (posedge clk_96MHz) begin
+  case (state)
+    IDLE: begin
+      if (enable == 1) begin
+        ready <= 0;
+        state <= ESTIMATE_ITERATION;
+      end else begin
+        ready <= 1;
+        polynomial <= 0;
+        iteration_number <= 0;
+      end
+    end
+
+    ESTIMATE_ITERATION: begin
+      if (ts_last_data < ts_last_data1) begin
+        estimated_iteration <= (ts_last_data1-ts_last_data)>>4;
+      end else begin
+        estimated_iteration <= (24'hffffff - ts_last_data + ts_last_data1)>>4;
+      end
+      state <= RUN_LFSR;
+    end
+
+    RUN_LFSR: begin
+      enable_LFSRs <= 1;
+      if (iteration_number_1D258 > (estimated_iteration - iteration_approx - 1)) begin
+        state <= IDENTIFY_POLYNOMIAL;
+      end
+    end
+
+    IDENTIFY_POLYNOMIAL: begin
+      if (value_1D258 == decoded_data1) begin
+        polynomial <= 17'h1d258;
+        iteration_number <= iteration_number_1D258;
+        enable_LFSRs <= 0;
+        state <= WAIT_FOR_RESET;
+      end else if (value_17E04 == decoded_data1) begin
+        polynomial <= 17'h17e04;
+        iteration_number <= iteration_number_17E04;
+        enable_LFSRs <= 0;
+        state <= WAIT_FOR_RESET;
+      end else if (iteration_number_1D258 > (estimated_iteration + iteration_approx) ) begin
+        enable_LFSRs <= 0;
+        state <= WAIT_FOR_RESET;
+      end
+    end
+
+    WAIT_FOR_RESET: begin
+      if (enable == 0) begin
+        state <= IDLE;
+      end else begin
+        ready <= 1;
+      end
+    end
+
+    default: ;
+  endcase
+end
+
+endmodule // polynomial_finder

--- a/FPGA/polynomial_finder/polynomial_finder_tb.v
+++ b/FPGA/polynomial_finder/polynomial_finder_tb.v
@@ -1,0 +1,37 @@
+module polynomial_finder_tb ();
+
+reg clk = 0;
+reg [23:0] ts_last_data = 24'h9C586A;
+reg [23:0] ts_last_data1 = 24'hA3B827;
+reg [16:0] decoded_data = 17'h149D0;
+reg [16:0] decoded_data1 = 17'h1C8F9;
+reg enable = 0;
+
+wire [16:0] polynomial;
+wire [16:0] iteration_number;
+wire ready;
+
+polynomial_finder poly_find(
+  .clk_96MHz (clk),
+  .ts_last_data (ts_last_data),
+  .ts_last_data1 (ts_last_data1),
+  .decoded_data (decoded_data),
+  .decoded_data1 (decoded_data1),
+  .enable (enable),
+  .polynomial (polynomial),
+  .iteration_number (iteration_number),
+  .ready (ready)
+  );
+
+always #1 clk <= ~clk;
+
+initial begin
+  $dumpfile("polynomial_finder_tb.vcd");
+  $dumpvars(0, polynomial_finder_tb);
+
+  #0 $display("start of simulation");
+  #5 enable <= 1;
+  #65000 $finish;
+end
+
+endmodule // polynomial_finder_tb

--- a/polynomials/decoded_bmc_polynomial_finder_tb.py
+++ b/polynomials/decoded_bmc_polynomial_finder_tb.py
@@ -1,0 +1,33 @@
+import sys
+
+sys.path.append("../")
+
+from bmc_decoder.bmc_decoder import SingleWord
+from polynomials.polynomial_finder import PolynomialIdentifier
+
+data = [
+    [0x0149D0, 0x9C586A],
+    [0x01C8F9, 0xA3B827],
+    [0x017949, 0xB99CF1],
+    [0x016765, 0xC0FC1B],
+    [0x01F75D, 0xD6E27E],
+    [0x01C8F9, 0xDE4049],
+    [0x017949, 0xF42514],
+    [0x01B29F, 0xFB84AE],
+    [0x0149D0, 0x1168A9],
+    [0x0191F2, 0x18C872],
+]
+
+clock_frequency = 96e6
+
+first_word = SingleWord(
+    waveform=[], start_timestamp=0x9C388 / clock_frequency, data=0x2955
+)
+second_word = SingleWord(
+    waveform=[], start_timestamp=0x9DE58 / clock_frequency, data=0x17B3D
+)
+
+identifier = PolynomialIdentifier(first_word, second_word)
+resulting_polys = identifier.search_polynomial()
+for i in resulting_polys:
+    print(i)


### PR DESCRIPTION
# Purpose of this PR

In order to find the number of LFSR iteration of each received data, we first need to find the polynomial of this pulse. This is the job of polynomial_finder module.

# What's happening in the module

*6 inputs:*
- clock (wire 1 bit)
- ts_last_data (wire 24 bits)
- ts_last_data1 (wire 24 bits)
- decoded_data (wire 17 bits)
- decoded_data1 (wire 17 bits)
- enable (wire 1 bit)

*3 outputs:*
- polynomial (reg 17 bits)
- iteration number (reg 17 bits)
- ready (reg 1 bit)

**ts_last_data is the timestamp of the first received decoded data decoded_data while ts_last_data1 is the timestamp of the second decoded data decoded_data1.**

The algorithm performed in this module is the exact same as the one described [in the trello]() but the 2 lfsr research is performed in parallel (only 2 lfsr because we're working with 0x1d258 and 0x17e04 polynomials only, not the 32 of the base stations).

When the research is finished, ready is switched to the logical level 1, if the polynomial register is different from 0, it means that the polynomial research was successful, else, no polynomial was found between 0x1d258 and 0x17e4. Iteration number between decoded_data and decoded_data1 is the output iteration_number until the next polynomial research.