### PR TITLE
FPGA offset_finder

### DIFF
--- a/FPGA/offset_finder/Makefile
+++ b/FPGA/offset_finder/Makefile
@@ -1,0 +1,67 @@
+#----------------------------------------
+#-- Name of the component
+#----------------------------------------
+NAME = offset_finder
+DEPS = ../lfsr/lfsr.v
+
+#-------------------------------------------------------
+#-- By default --> simulation and synthesis
+#-------------------------------------------------------
+all: sim sint
+
+#----------------------------------------------
+#-- make sim
+#----------------------------------------------
+#-- Make the simulation given by the test bench
+#----------------------------------------------
+sim: $(NAME)_tb.vcd
+
+#-----------------------------------------------
+#-  make sint
+#-----------------------------------------------
+#-  Make the synthesis for icestick FPGA
+#-----------------------------------------------
+sint: $(NAME).bin
+
+#-----------------------------------------------
+#-  make flash
+#-----------------------------------------------
+#-  Flash the icestick FPGA with the bitstream
+#-----------------------------------------------
+flash:
+	sudo iceprog $(NAME).bin
+
+#-------------------------------
+#-- Compilation and simulation
+#-------------------------------
+$(NAME)_tb.vcd: $(NAME).v $(NAME)_tb.v $(DEPS)
+
+	#-- Compilation
+	iverilog $^ -o $(NAME)_tb.out
+
+	#-- Simulation
+	./$(NAME)_tb.out
+
+	#-- To see the simulation in gtkwave
+	gtkwave $@ $(NAME)_tb.gtkw &
+
+#------------------------------
+#-- Complete synthesis
+#------------------------------
+$(NAME).bin: $(NAME).pcf $(NAME).v
+
+	#-- Synthesis
+	yosys -p "synth_ice40 -blif $(NAME).blif" $(NAME).v $(DEPS)
+
+	#-- Place & route
+	arachne-pnr -d 1k -p $(NAME).pcf $(NAME).blif -o $(NAME).txt
+
+	#-- Generate final bitstrem file
+	icepack $(NAME).txt $(NAME).bin
+
+
+#-- Limpiar todo
+clean:
+	rm -f *.bin *.txt *.blif *.out *.vcd *~
+
+.PHONY: all clean

--- a/FPGA/offset_finder/offset_finder.v
+++ b/FPGA/offset_finder/offset_finder.v
@@ -1,0 +1,132 @@
+`default_nettype none
+
+module offset_finder (
+  input wire clk_96MHz,
+  input wire [16:0] polynomial,
+  input wire [16:0] data,
+  input wire enable,
+
+  output reg [16:0] offset,
+  output reg ready
+  );
+
+parameter iteration_timeout = 29970; //=( lfsr_frequency(6e6)/moteur_frequency(48e6/959e3) ) / 4
+
+
+localparam  IDLE = 0;
+localparam  LOAD = 1;
+localparam  RUN = 2;
+localparam  DATA_READY = 3;
+
+reg [1:0] state = IDLE;
+
+reg [16:0] start_data_1;
+reg [16:0] start_data_2;
+reg [16:0] start_data_3;
+
+wire [16:0] value_LFSR_0;
+wire [16:0] value_LFSR_1;
+wire [16:0] value_LFSR_2;
+wire [16:0] value_LFSR_3;
+
+wire [16:0] iteration_number_0;
+wire [16:0] iteration_number_1;
+wire [16:0] iteration_number_2;
+wire [16:0] iteration_number_3;
+
+reg enable_LFSRs = 0;
+
+lfsr LFSR_0 (
+  .clk_96MHz (clk_96MHz),
+  .polynomial (polynomial),
+  .start_data (17'h1),
+  .enable (enable_LFSRs),
+  .value (value_LFSR_0),
+  .iteration_number (iteration_number_0)
+  );
+
+lfsr LFSR_1 (
+  .clk_96MHz (clk_96MHz),
+  .polynomial (polynomial),
+  .start_data (start_data_1),
+  .enable (enable_LFSRs),
+  .value (value_LFSR_1),
+  .iteration_number (iteration_number_1)
+  );
+
+lfsr LFSR_2 (
+  .clk_96MHz (clk_96MHz),
+  .polynomial (polynomial),
+  .start_data (start_data_2),
+  .enable (enable_LFSRs),
+  .value (value_LFSR_2),
+  .iteration_number (iteration_number_2)
+  );
+
+lfsr LFSR_3 (
+  .clk_96MHz (clk_96MHz),
+  .polynomial (polynomial),
+  .start_data (start_data_3),
+  .enable (enable_LFSRs),
+  .value (value_LFSR_3),
+  .iteration_number (iteration_number_3)
+  );
+
+
+always @ (posedge clk_96MHz) begin
+  case (state)
+    IDLE: begin
+      if (enable == 1) begin
+        ready <= 0;
+        state <= LOAD;
+      end else begin
+        ready <= 1;
+      end
+    end
+
+    LOAD: begin
+      if (polynomial == 17'h1d258) begin
+        start_data_1 <= 17'he844;
+        start_data_2 <= 17'h1f555;
+        start_data_3 <= 17'h13786;
+      end else begin
+        start_data_1 <= 17'h14e50;
+        start_data_2 <= 17'h1e295;
+        start_data_3 <= 17'h8c4b;
+      end
+      state <= RUN;
+    end
+
+    RUN: begin
+      enable_LFSRs <= 1;
+      if (value_LFSR_0 == data) begin
+        offset <= iteration_number_0;
+        state <= DATA_READY;
+      end else if (value_LFSR_1 == data) begin
+        offset <= iteration_number_1 + iteration_timeout;
+        state <= DATA_READY;
+      end else if (value_LFSR_2 == data) begin
+        offset <= iteration_number_2 + iteration_timeout * 2;
+        state <= DATA_READY;
+      end else if (value_LFSR_3 == data) begin
+        offset <= iteration_number_3 + iteration_timeout * 3;
+        state <= DATA_READY;
+      end else if (iteration_number_0 == iteration_timeout) begin
+        offset <= 0;
+        state <= DATA_READY;
+      end
+    end
+
+    DATA_READY: begin
+      enable_LFSRs <= 0;
+      ready <= 1;
+      if (enable == 0) begin
+        state <= IDLE;
+      end
+    end
+
+    default: ;
+  endcase
+end
+
+endmodule // offset_finder

--- a/FPGA/offset_finder/offset_finder_tb.v
+++ b/FPGA/offset_finder/offset_finder_tb.v
@@ -1,0 +1,35 @@
+module offset_finder_tb ();
+
+reg clk = 0;
+reg [16:0] polynomial = 17'h17e04;
+reg [16:0] data = 17'h189d5;
+reg enable = 0;
+
+wire [16:0] offset;
+wire ready;
+
+offset_finder dut(
+  .clk_96MHz (clk),
+  .polynomial (polynomial),
+  .data (data),
+  .enable (enable),
+  .offset (offset),
+  .ready (ready)
+  );
+
+always #1 clk <= ~clk;
+
+initial begin
+  $dumpfile("offset_finder_tb.vcd");
+  $dumpvars(0, offset_finder_tb);
+
+  #0 $display("start of simulation");
+  #5 enable <= 1;
+  #64000 enable <= 0;
+  #3 polynomial = 17'h1d258;
+  #3 data <= 17'h42b2;
+  #1 enable <= 1;
+  #64000 $finish;
+end
+
+endmodule // offset_finder_tb


### PR DESCRIPTION
# Purpose of this PR
In order to know what iteration of LFSR the received and decoded data is, we need to find the polynomial using polynomial_finder module, then we need to run an LFSR with the polynomial found and starting at 1. This is the idea of this module.

# What's happening in this module ?

*4 inputs:*
- clock (wire 1 bit)
- polynomial, the polynomial retrieved (wire 17 bits)
- data, the data we're looking for (wire 17 bits)
- enable (wire 1 bit)

*2 outputs:*
- offset, the number of iteration found (reg 17 bits)
- ready (reg 1 bit)

For this module to get the iteration wanted even faster, it runs 4 LFSR in parallel, one starting at the iteration 0 with the value 1, one at the max_iteration/4 iteration with the value associated, another at 2*max_iteration/4 iteration with the value associated and the last at 3*max_iteration/4 iteration with the value associated.

At each positive edge clock signal, values of the 4 LFSR are compared to the value searched, and if it is the researched value, ready is switches to logical 1 level and the offset (number of iteration) can be retrieve is offset value. If all possible iterations have been processed and no correspondence found, ready is switched to logical level but the offset is 0.