### PR TITLE
FPGA pulse_identifier

### DIFF
--- a/FPGA/pulse_identifier/Makefile
+++ b/FPGA/pulse_identifier/Makefile
@@ -1,0 +1,67 @@
+#----------------------------------------
+#-- Name of the component
+#----------------------------------------
+NAME = pulse_identifier
+DEPS = ../polynomial_finder/polynomial_finder.v ../lfsr/lfsr.v ../offset_finder/offset_finder.v
+
+#-------------------------------------------------------
+#-- By default --> simulation and synthesis
+#-------------------------------------------------------
+all: sim sint
+
+#----------------------------------------------
+#-- make sim
+#----------------------------------------------
+#-- Make the simulation given by the test bench
+#----------------------------------------------
+sim: $(NAME)_tb.vcd
+
+#-----------------------------------------------
+#-  make sint
+#-----------------------------------------------
+#-  Make the synthesis for icestick FPGA
+#-----------------------------------------------
+sint: $(NAME).bin
+
+#-----------------------------------------------
+#-  make flash
+#-----------------------------------------------
+#-  Flash the icestick FPGA with the bitstream
+#-----------------------------------------------
+flash:
+	sudo iceprog $(NAME).bin
+
+#-------------------------------
+#-- Compilation and simulation
+#-------------------------------
+$(NAME)_tb.vcd: $(NAME).v $(NAME)_tb.v $(DEPS)
+
+	#-- Compilation
+	iverilog $^ -o $(NAME)_tb.out
+
+	#-- Simulation
+	./$(NAME)_tb.out
+
+	#-- To see the simulation in gtkwave
+	gtkwave $@ $(NAME)_tb.gtkw &
+
+#------------------------------
+#-- Complete synthesis
+#------------------------------
+$(NAME).bin: $(NAME).pcf $(NAME).v
+
+	#-- Synthesis
+	yosys -p "synth_ice40 -blif $(NAME).blif" $(NAME).v $(DEPS)
+
+	#-- Place & route
+	arachne-pnr -d 1k -p $(NAME).pcf $(NAME).blif -o $(NAME).txt
+
+	#-- Generate final bitstrem file
+	icepack $(NAME).txt $(NAME).bin
+
+
+#-- Limpiar todo
+clean:
+	rm -f *.bin *.txt *.blif *.out *.vcd *~
+
+.PHONY: all clean

--- a/FPGA/pulse_identifier/pulse_identifier.v
+++ b/FPGA/pulse_identifier/pulse_identifier.v
@@ -1,0 +1,192 @@
+`default_nettype none
+
+module pulse_identifier (
+  input wire clk_96MHz,
+  input wire data_availible,
+  input wire data_availible1,
+  input wire [23:0] ts_data,
+  input wire [23:0] ts_data1,
+  input wire [16:0] decoded_data,
+  input wire [16:0] decoded_data1,
+  input wire reset,
+
+  output reg [16:0] pulse_id_0,
+  output reg [16:0] pulse_id_1,
+  output wire [16:0] polynomial,
+  output reg reset_bmc_decoder_0,
+  output reg reset_bmc_decoder_1,
+  output reg ready
+  );
+
+parameter timeout_ticks = 100000; //~1ms in a 96MHz clock frequency
+
+localparam  WAITING_FOR_DATA = 0;
+localparam  STORING_NEW_DATA = 1;
+localparam  POLYNOMIAL_IDENTIFICATION = 2;
+localparam  WAITING_FOR_LAST_DATA = 3;
+localparam  OFFSET_IDENTIFICATION = 4;
+localparam  DATA_READY = 5;
+localparam  ERROR_OR_RESET = 6;
+
+reg [3:0] state = ERROR_OR_RESET;
+
+reg [1:0] number_of_data_received_this_pulse;
+
+reg [16:0] first_data, second_data;
+reg [23:0] ts_first_data, ts_second_data;
+reg [1:0] first_sensor;
+reg [1:0] second_sensor;
+
+reg [16:0] waiting_timer;
+reg enable_waiting_timer;
+
+always @ (posedge clk_96MHz) begin
+  if (enable_waiting_timer == 1) begin
+    waiting_timer <= waiting_timer + 1;
+  end
+end
+
+reg enable_polynomial_finder;
+wire [16:0] iteration_between_first_second;
+wire polynomial_finder_ready;
+reg wait_for_module_activation = 0;
+
+polynomial_finder POLY_FINDER(
+  .clk_96MHz (clk_96MHz),
+  .ts_last_data (ts_first_data),
+  .ts_last_data1 (ts_second_data),
+  .decoded_data (first_data),
+  .decoded_data1 (second_data),
+  .enable (enable_polynomial_finder),
+  .polynomial (polynomial),
+  .iteration_number (iteration_between_first_second),
+  .ready (polynomial_finder_ready)
+  );
+
+reg offset_finder_enable;
+wire [16:0] offset_first_pulse;
+wire offset_finder_ready;
+
+offset_finder OFFSET_FINDER0(
+  .clk_96MHz (clk_96MHz),
+  .polynomial (polynomial),
+  .data (first_data),
+  .enable (offset_finder_enable),
+  .offset (offset_first_pulse),
+  .ready (offset_finder_ready)
+  );
+
+always @ (posedge clk_96MHz) begin
+  case (state)
+    WAITING_FOR_DATA: begin
+      if (waiting_timer == timeout_ticks) begin
+        state <= ERROR_OR_RESET;
+      end else if ((data_availible || data_availible1) && (reset_bmc_decoder_0 == 0 && reset_bmc_decoder_1 == 0) ) begin
+        state <= STORING_NEW_DATA;
+      end
+      ready <= 0;
+      reset_bmc_decoder_0 <= 0;
+      reset_bmc_decoder_1 <= 0;
+    end
+
+    STORING_NEW_DATA: begin
+      if (number_of_data_received_this_pulse == 0) begin
+        if (data_availible == 1) begin
+          first_data <= decoded_data;
+          ts_first_data <= ts_data;
+          reset_bmc_decoder_0 <= 1;
+          first_sensor <= 0;
+        end else if (data_availible1 == 1) begin
+          first_data <= decoded_data1;
+          ts_first_data <= ts_data1;
+          reset_bmc_decoder_1 <= 1;
+          first_sensor <= 1;
+        end
+        number_of_data_received_this_pulse <= 1;
+        enable_waiting_timer <= 1;
+        state <= WAITING_FOR_DATA;
+      end else begin
+        if (data_availible == 1) begin
+          second_data <= decoded_data;
+          ts_second_data <= ts_data;
+          reset_bmc_decoder_0 <= 1;
+          second_sensor <= 0;
+        end else if (data_availible1 == 1) begin
+          second_data <= decoded_data1;
+          ts_second_data <= ts_data1;
+          reset_bmc_decoder_1 <= 1;
+          second_sensor <= 1;
+        end
+        wait_for_module_activation <= 1;
+        state <= POLYNOMIAL_IDENTIFICATION;
+      end
+    end
+
+    POLYNOMIAL_IDENTIFICATION: begin
+      reset_bmc_decoder_0 <= 0;
+      reset_bmc_decoder_1 <= 0;
+      enable_polynomial_finder <= 1;
+      if (polynomial_finder_ready == 1) begin
+        if (wait_for_module_activation) begin
+        end else if (polynomial == 0) begin
+          state <= ERROR_OR_RESET;
+        end else begin
+          state <= WAITING_FOR_LAST_DATA;
+        end
+      end else if (wait_for_module_activation == 1 && polynomial_finder_ready == 0) begin
+        wait_for_module_activation <= 0;
+      end
+    end
+
+    WAITING_FOR_LAST_DATA: begin
+      enable_waiting_timer <= 0;
+      wait_for_module_activation <= 1;
+      state <= OFFSET_IDENTIFICATION;
+    end
+
+    OFFSET_IDENTIFICATION: begin
+      offset_finder_enable <= 1;
+      if (offset_finder_ready == 1) begin
+        if (wait_for_module_activation) begin
+        end else if (offset_first_pulse != 0) begin
+          pulse_id_0 <= (first_sensor == 0) ? offset_first_pulse : offset_first_pulse + iteration_between_first_second;
+          pulse_id_1 <= (first_sensor == 1) ? offset_first_pulse : offset_first_pulse + iteration_between_first_second;
+          state <= DATA_READY;
+        end else begin
+          state <= ERROR_OR_RESET;
+        end
+      end else if (wait_for_module_activation == 1 && offset_finder_ready == 0) begin
+        wait_for_module_activation <= 0;
+      end
+    end
+
+    DATA_READY: begin
+      ready <= 1;
+      if (reset == 1) begin
+        ready <= 0;
+        state <= ERROR_OR_RESET;
+      end
+    end
+
+    ERROR_OR_RESET: begin
+      number_of_data_received_this_pulse <= 0;
+      first_data <= 0;
+      second_data <= 0;
+      ts_first_data <= 0;
+      ts_second_data <= 0;
+      waiting_timer <= 0;
+      enable_waiting_timer <= 0;
+      first_sensor <= 0;
+      second_sensor <= 0;
+      enable_polynomial_finder <= 0;
+      offset_finder_enable <= 0;
+      pulse_id_0 <= 0;
+      pulse_id_1 <= 0;
+      state <= WAITING_FOR_DATA;
+    end
+
+    default: ;
+  endcase
+end
+
+endmodule // pulse_identifier

--- a/FPGA/pulse_identifier/pulse_identifier_tb.v
+++ b/FPGA/pulse_identifier/pulse_identifier_tb.v
@@ -1,0 +1,74 @@
+module pulse_identifier_tb ();
+
+reg clk = 0;
+reg data_availible = 0;
+reg data_availible1 = 0;
+reg [23:0] ts_data = 24'h9c388;
+reg [23:0] ts_data1 = 24'h9de58;
+reg [16:0] decoded_data = 17'h2955;
+reg [16:0] decoded_data1 = 17'h17b3d;
+reg reset = 0;
+
+wire [16:0] pulse_id_0;
+wire [16:0] pulse_id_1;
+wire [16:0] polynomial;
+wire reset_bmc_decoder_0;
+wire reset_bmc_decoder_1;
+wire ready;
+
+pulse_identifier dut(
+  .clk_96MHz (clk),
+  .data_availible (data_availible),
+  .data_availible1 (data_availible1),
+  .ts_data (ts_data),
+  .ts_data1 (ts_data1),
+  .decoded_data (decoded_data),
+  .decoded_data1 (decoded_data1),
+  .reset (reset),
+  .pulse_id_0 (pulse_id_0),
+  .pulse_id_1 (pulse_id_1),
+  .polynomial (polynomial),
+  .reset_bmc_decoder_0 (reset_bmc_decoder_0),
+  .reset_bmc_decoder_1 (reset_bmc_decoder_1),
+  .ready (ready)
+  );
+
+always #1 clk <= ~clk;
+
+always @ (posedge clk) begin
+  if (reset_bmc_decoder_0 == 1) begin
+    data_availible <= 0;
+  end
+end
+
+always @ (posedge clk) begin
+  if (reset_bmc_decoder_1 == 1) begin
+    data_availible1 <= 0;
+  end
+end
+
+always @ (posedge clk) begin
+  if (ready == 1) begin
+    reset <= 1;
+  end else if (ready == 0 && reset == 1) begin
+    reset <= 0;
+  end
+end
+
+initial begin
+  $dumpfile("pulse_identifier_tb.vcd");
+  $dumpvars(0, pulse_identifier_tb);
+
+  #0 $display("start of simulation");
+  #5 data_availible <= 1;
+  #(6864*2) data_availible1 <= 1;
+  #50 ts_data <= 24'h9de58;
+  ts_data1 <= 24'h9c388;
+  decoded_data <= 17'h17b3d;
+  decoded_data1 <= 17'h2955;
+  #32000 data_availible1 <= 1;
+  #(6864*2) data_availible <= 1;
+  #32000 $finish;
+end
+
+endmodule // pulse_identifier_tb

--- a/bmc_decoder/test_bench_pulse_identification_validation.py
+++ b/bmc_decoder/test_bench_pulse_identification_validation.py
@@ -1,0 +1,29 @@
+from bmc_decoder import BMC_decoder
+
+bmc_decoder = BMC_decoder("test")
+
+bmc_decoder.decode_whole_document()
+
+words = bmc_decoder.get_first_and_last_word_from_beam(0)
+
+for word in words:
+    print(hex(int(word.start_timestamp * 96000000)))
+    print(word)
+
+print(words[1].start_timestamp - words[0].start_timestamp)
+print((0x9DE58 - 0x9C388) / 96000000)
+print(0x9DE58 - 0x9C388)
+
+"""
+first word: 0x2955,
+ts: 0x9c388
+
+second_word: 0x17b3d,
+ts: 0x9de58
+
+iteration between both: 429
+polynomial: 1d258
+
+iteration first: 45388
+iteration second: 45817
+"""


### PR DESCRIPTION
# Purpose of this PR

In order to triangulate the system, we need at least 3 values of iterations for at least 3 sensors twice. The goal of the pulse_identifier module is to get decoded data from 3 sensors and compute the iterations needed for each sensor.

**For the moment only 2 sensors are managed for testing purpose.**

# What's happening in this module

*8 inputs:*
- clock (wire 1 bit)
- data_availible, "ready" wire of the first bmc_decoder (wire 1 bit)
- data_availible1, "ready" wire of the second bmc_decoder (wire 1 bit)
- ts_data, timestamp value of the data from the first bmc_decoder (wire 24 bits)
- ts_data1, timestamp value of the data from the second bmc_decoder (wire 24 bits)
- decoded_data, decoded data from the first bmc_decoder (wire 17 bits)
- decoded_data1, decoded data from the second bmc_decoder (wire 17 bits)
- reset (wire 1 bit)

*6 outputs:*
- pulse_id_0, number of iteration of sensor_0 (reg 17 bits)
- pulse_id_1, number of iteration of sensor_1 (reg 17 bits)
- polynomial, the polynomial retrieved for this pulse (reg 17 bits)
- reset_bmc_decoder_0 (reg 1 bit)
- reset_bmc_decoder_1 (reg 1 bit)
- ready (reg 1 bit)

The module:
- This module constantly checks if new data are available in bmc_decoder module 0 and 1. 
- If so, the decoded_data are retrieve and stored in another 17 bits register, the timestamp of this data too.
- If 2 data has been retrieved in less than 1 ms, a search for the polynomial of this pulse is launched.
- If the polynomial research is a success, a search of the iteration of the first retrieved data is launched. 
- If the offset is found, the 2 pulse_id are set and ready wire is set to logical one.
- Once the reset wire is set to logical level one, the whole module is reset and restarted .

# Extra

An extra machine state has been implemented to develop the module with 3 sensors easily.