### PR TITLE
FPGA architecture refactoring

### DIFF
--- a/FPGA/bmc_decoder/bmc_decoder.v
+++ b/FPGA/bmc_decoder/bmc_decoder.v
@@ -8,17 +8,17 @@ module bmc_decoder #(
   input wire d_in_1,
   input wire e_in_0,
   input wire enabled,
-  input wire [23:0] system_timestamp,
+  input wire [23:0] sys_ts,
   input wire reset,
 
   output reg [bit_considered-1:0] decoded_data,
   output reg data_availible,
-  output reg [23:0] timestamp_last_data,
+  output reg [23:0] ts_last_data,
 
   output wire state_led
   );
 
-parameter too_fast_counter = 3;
+parameter too_fast_counter = 2;
 parameter fast_counter = 11;
 parameter slow_counter = 11;
 parameter timeout_counter = 24;
@@ -142,7 +142,7 @@ always @ (posedge clk_96MHz) begin
       DATA_AVAILIBLE: begin
         data_availible <= 1;
         decoded_data <= data_buffer;
-        timestamp_last_data <= system_timestamp;
+        ts_last_data <= sys_ts;
         sampling_ena <= 0;
         tick_counter <= 0;
         state <= WAITING_TIME;

--- a/FPGA/inout_face_manager/inout_face_manager.v
+++ b/FPGA/inout_face_manager/inout_face_manager.v
@@ -5,28 +5,38 @@ module inout_face_manager (
 
 
   inout wire data_wire_0,
-  input wire d_oe_0,
-  input wire d_out_0,
-  output reg d_in_first_0,
-  output reg d_in_second_0,
-
-  inout wire envelop_wire_0,
-  input wire e_oe_0,
-  input wire e_out_0,
-  output reg e_in_0,
-
+  input wire d_0_oe,
+  input wire d_0_out,
+  output reg d_0_in_0,
+  output reg d_0_in_1,
 
   inout wire data_wire_1,
-  input wire d_oe_1,
-  input wire d_out_1,
-  output reg d_in_first_1,
-  output reg d_in_second_1,
+  input wire d_1_oe,
+  input wire d_1_out,
+  output reg d_1_in_0,
+  output reg d_1_in_1,
+
+  inout wire data_wire_2,
+  input wire d_2_oe,
+  input wire d_2_out,
+  output reg d_2_in_0,
+  output reg d_2_in_1,
+
+
+  inout wire envelop_wire_0,
+  input wire e_0_oe,
+  input wire e_0_out,
+  output reg e_0_in,
 
   inout wire envelop_wire_1,
-  input wire e_oe_1,
-  input wire e_out_1,
-  output reg e_in_1
+  input wire e_1_oe,
+  input wire e_1_out,
+  output reg e_1_in,
 
+  inout wire envelop_wire_2,
+  input wire e_2_oe,
+  input wire e_2_out,
+  output reg e_2_in
   );
 
 wire d_in_0_no_reg;
@@ -35,62 +45,91 @@ wire e_in_0_no_reg;
 wire d_in_1_no_reg;
 wire e_in_1_no_reg;
 
+wire d_in_2_no_reg;
+wire e_in_2_no_reg;
+
 reg buffer_0;
 reg buffer_1;
+reg buffer_2;
 
 (* IO_TYPE="LVCMOS33" *)
 TRELLIS_IO #(.DIR("BIDIR"))
   inout_data_0 (
     .B(data_wire_0),
-    .I(d_out_0),
+    .I(d_0_out),
     .O(d_in_0_no_reg),
-    .T(!d_oe_0)
+    .T(!d_0_oe)
     );
-
-(* IO_TYPE="LVCMOS33" *)
-TRELLIS_IO #(.DIR("BIDIR"))
-  inout_envelop_0 (
-    .B(envelop_wire_0),
-    .I(e_out_0),
-    .O(e_in_0_no_reg),
-    .T(!e_oe_0)
-    );
-
-
 
 (* IO_TYPE="LVCMOS33" *)
 TRELLIS_IO #(.DIR("BIDIR"))
   inout_data_1 (
     .B(data_wire_1),
-    .I(d_out_1),
+    .I(d_1_out),
     .O(d_in_1_no_reg),
-    .T(!d_oe_1)
+    .T(!d_1_oe)
+    );
+
+(* IO_TYPE="LVCMOS33" *)
+TRELLIS_IO #(.DIR("BIDIR"))
+  inout_data_2 (
+    .B(data_wire_2),
+    .I(d_2_out),
+    .O(d_in_2_no_reg),
+    .T(!d_2_oe)
+    );
+
+
+
+(* IO_TYPE="LVCMOS33" *)
+TRELLIS_IO #(.DIR("BIDIR"))
+  inout_envelop_0 (
+    .B(envelop_wire_0),
+    .I(e_0_out),
+    .O(e_in_0_no_reg),
+    .T(!e_0_oe)
     );
 
 (* IO_TYPE="LVCMOS33" *)
 TRELLIS_IO #(.DIR("BIDIR"))
   inout_envelop_1 (
     .B(envelop_wire_1),
-    .I(e_out_1),
+    .I(e_1_out),
     .O(e_in_1_no_reg),
-    .T(!e_oe_1)
+    .T(!e_1_oe)
+    );
+    
+(* IO_TYPE="LVCMOS33" *)
+TRELLIS_IO #(.DIR("BIDIR"))
+  inout_envelop_2 (
+    .B(envelop_wire_2),
+    .I(e_2_out),
+    .O(e_in_2_no_reg),
+    .T(!e_2_oe)
     );
 
+
 always @ (posedge clk_96MHz) begin
-  d_in_first_0 <= d_in_0_no_reg;
-  d_in_second_0 <= buffer_0;
+  d_0_in_0 <= d_in_0_no_reg;
+  d_0_in_1 <= buffer_0;
 
-  d_in_first_1 <= d_in_1_no_reg;
-  d_in_second_1 <= buffer_1;
+  d_1_in_0 <= d_in_1_no_reg;
+  d_1_in_1 <= buffer_1;
 
-  e_in_0 <= e_in_0_no_reg;
+  d_2_in_0 <= d_in_2_no_reg;
+  d_2_in_1 <= buffer_2;
 
-  e_in_1 <= e_in_1_no_reg;
+  e_0_in <= e_in_0_no_reg;
+
+  e_1_in <= e_in_1_no_reg;
+
+  e_2_in <= e_in_2_no_reg;
 end
 
 always @ (negedge clk_96MHz) begin
-  buffer_0 <= d_in_first_0;
-  buffer_1 <= d_in_first_1;
+  buffer_0 <= d_0_in_0;
+  buffer_1 <= d_1_in_0;
+  buffer_2 <= d_2_in_0;
 end
 
 endmodule // inout_face_manager

--- a/FPGA/pulse_identifier/pulse_identifier.v
+++ b/FPGA/pulse_identifier/pulse_identifier.v
@@ -6,50 +6,63 @@ module pulse_identifier (
   input wire clk_96MHz,
   input wire data_availible,
   input wire data_availible1,
+  input wire data_availible2,
   input wire [23:0] ts_data,
   input wire [23:0] ts_data1,
+  input wire [23:0] ts_data2,
   input wire [16:0] decoded_data,
   input wire [16:0] decoded_data1,
+  input wire [16:0] decoded_data2,
   input wire reset,
 
   output reg [16:0] pulse_id_0,
   output reg [16:0] pulse_id_1,
+  output reg [16:0] pulse_id_2,
   output wire [16:0] polynomial,
   output reg reset_bmc_decoder_0,
   output reg reset_bmc_decoder_1,
-  output reg ready
+  output reg reset_bmc_decoder_2,
+  output reg ready,
+
+  output wire state_led,
+  input wire [23:0] sys_ts
   );
 
-parameter timeout_ticks = 100000; //~1ms in a 96MHz clock frequency
+parameter timeout_ticks = 50000; //~1ms in a 96MHz clock frequency
 
 localparam  WAITING_FOR_DATA = 0;
 localparam  STORING_NEW_DATA = 1;
-localparam  POLYNOMIAL_IDENTIFICATION = 2;
-localparam  WAITING_FOR_LAST_DATA = 3;
-localparam  OFFSET_IDENTIFICATION = 4;
-localparam  DATA_READY = 5;
-localparam  ERROR_OR_RESET = 6;
+localparam  START_THIRD_SENSOR_WAIT = 2;
+localparam  POLYNOMIAL_IDENTIFICATION = 3;
+localparam  WAITING_FOR_LAST_DATA = 4;
+localparam  OFFSET_IDENTIFICATION = 5;
+localparam  DATA_READY = 6;
+localparam  ERROR_OR_RESET = 7;
 
 reg [3:0] state = ERROR_OR_RESET;
 
 reg [1:0] number_of_data_received_this_pulse;
 
 reg [16:0] first_data, second_data;
-reg [23:0] ts_first_data, ts_second_data;
+reg [23:0] ts_first_data, ts_second_data, ts_third_data;
 reg [1:0] first_sensor;
 reg [1:0] second_sensor;
+reg [1:0] third_sensor;
 
 reg [16:0] waiting_timer;
 reg enable_waiting_timer;
 
 always @ (posedge clk_96MHz) begin
-  if (enable_waiting_timer == 1) begin
+  if (enable_waiting_timer == 1 && waiting_timer != timeout_ticks) begin
     waiting_timer <= waiting_timer + 1;
+  end else if (enable_waiting_timer == 0) begin
+    waiting_timer <= 0;
   end
 end
 
 reg enable_polynomial_finder;
 wire [16:0] iteration_between_first_second;
+reg [16:0] iteration_between_first_third;
 wire polynomial_finder_ready;
 reg wait_for_module_activation = 0;
 
@@ -79,16 +92,30 @@ offset_finder OFFSET_FINDER0(
   );
 
 always @ (posedge clk_96MHz) begin
+  if (third_sensor == 0 && data_availible && waiting_timer != timeout_ticks) begin
+    ts_third_data <= ts_data;
+  end else if (third_sensor == 1 && data_availible1 && waiting_timer != timeout_ticks) begin
+    ts_third_data <= ts_data1;
+  end else if (third_sensor == 2 && data_availible2 && waiting_timer != timeout_ticks) begin
+    ts_third_data <= ts_data2;
+  end else if (third_sensor == 3) begin
+    ts_third_data <= 0;
+  end
+end
+
+always @ (posedge clk_96MHz) begin
   case (state)
     WAITING_FOR_DATA: begin
       if (waiting_timer == timeout_ticks) begin
         state <= ERROR_OR_RESET;
-      end else if ((data_availible || data_availible1) && (reset_bmc_decoder_0 == 0 && reset_bmc_decoder_1 == 0) ) begin
-        state <= STORING_NEW_DATA;
+      end else if ((data_availible || data_availible1 || data_availible2)
+        && (reset_bmc_decoder_0 == 0 && reset_bmc_decoder_1 == 0 && reset_bmc_decoder_2 == 0) ) begin
+          state <= STORING_NEW_DATA;
       end
       ready <= 0;
       reset_bmc_decoder_0 <= 0;
       reset_bmc_decoder_1 <= 0;
+      reset_bmc_decoder_2 <= 0;
     end
 
     STORING_NEW_DATA: begin
@@ -103,6 +130,11 @@ always @ (posedge clk_96MHz) begin
           ts_first_data <= ts_data1;
           reset_bmc_decoder_1 <= 1;
           first_sensor <= 1;
+        end else if (data_availible2 == 1) begin
+          first_data <= decoded_data2;
+          ts_first_data <= ts_data2;
+          reset_bmc_decoder_2 <= 1;
+          first_sensor <= 2;
         end
         number_of_data_received_this_pulse <= 1;
         enable_waiting_timer <= 1;
@@ -118,15 +150,34 @@ always @ (posedge clk_96MHz) begin
           ts_second_data <= ts_data1;
           reset_bmc_decoder_1 <= 1;
           second_sensor <= 1;
+        end else if (data_availible2 == 1) begin
+          second_data <= decoded_data2;
+          ts_second_data <= ts_data2;
+          reset_bmc_decoder_2 <= 1;
+          second_sensor <= 2;
         end
         wait_for_module_activation <= 1;
-        state <= POLYNOMIAL_IDENTIFICATION;
+        state <= START_THIRD_SENSOR_WAIT;
       end
+    end
+
+    START_THIRD_SENSOR_WAIT: begin
+      if ((first_sensor == 0 || first_sensor == 1)
+      && (second_sensor == 0 || second_sensor == 1)) begin
+        third_sensor <= 2;
+      end else if ((first_sensor == 0 || first_sensor == 2)
+      && (second_sensor == 0 || second_sensor == 2)) begin
+        third_sensor <= 1;
+      end else begin
+        third_sensor <= 0;
+      end
+      state <= POLYNOMIAL_IDENTIFICATION;
     end
 
     POLYNOMIAL_IDENTIFICATION: begin
       reset_bmc_decoder_0 <= 0;
       reset_bmc_decoder_1 <= 0;
+      reset_bmc_decoder_2 <= 0;
       enable_polynomial_finder <= 1;
       if (polynomial_finder_ready == 1) begin
         if (wait_for_module_activation) begin
@@ -141,9 +192,18 @@ always @ (posedge clk_96MHz) begin
     end
 
     WAITING_FOR_LAST_DATA: begin
-      enable_waiting_timer <= 0;
-      wait_for_module_activation <= 1;
-      state <= OFFSET_IDENTIFICATION;
+      if (ts_third_data != 0) begin
+        enable_waiting_timer <= 0;
+        if (ts_first_data < ts_third_data) begin
+          iteration_between_first_third <= (ts_third_data-ts_first_data)>>4;
+        end else begin
+          iteration_between_first_third <= (24'hffffff - ts_first_data + ts_third_data)>>4;
+        end
+        wait_for_module_activation <= 1;
+        state <= OFFSET_IDENTIFICATION;
+      end else if (waiting_timer == timeout_ticks) begin
+        state <= ERROR_OR_RESET;
+      end
     end
 
     OFFSET_IDENTIFICATION: begin
@@ -151,8 +211,31 @@ always @ (posedge clk_96MHz) begin
       if (offset_finder_ready == 1) begin
         if (wait_for_module_activation) begin
         end else if (offset_first_pulse != 0) begin
-          pulse_id_0 <= (first_sensor == 0) ? offset_first_pulse : offset_first_pulse + iteration_between_first_second;
-          pulse_id_1 <= (first_sensor == 1) ? offset_first_pulse : offset_first_pulse + iteration_between_first_second;
+
+          if (first_sensor == 0) begin
+            pulse_id_0 <= offset_first_pulse;
+          end else if (second_sensor == 0) begin
+            pulse_id_0 <= offset_first_pulse + iteration_between_first_second;
+          end else begin
+            pulse_id_0 <= offset_first_pulse + iteration_between_first_third;
+          end
+
+          if (first_sensor == 1) begin
+            pulse_id_1 <= offset_first_pulse;
+          end else if (second_sensor == 1) begin
+            pulse_id_1 <= offset_first_pulse + iteration_between_first_second;
+          end else begin
+            pulse_id_1 <= offset_first_pulse + iteration_between_first_third;
+          end
+
+          if (first_sensor == 2) begin
+            pulse_id_2 <= offset_first_pulse;
+          end else if (second_sensor == 2) begin
+            pulse_id_2 <= offset_first_pulse + iteration_between_first_second;
+          end else begin
+            pulse_id_2 <= offset_first_pulse + iteration_between_first_third;
+          end
+
           state <= DATA_READY;
         end else begin
           state <= ERROR_OR_RESET;
@@ -176,19 +259,31 @@ always @ (posedge clk_96MHz) begin
       second_data <= 0;
       ts_first_data <= 0;
       ts_second_data <= 0;
-      waiting_timer <= 0;
       enable_waiting_timer <= 0;
       first_sensor <= 0;
       second_sensor <= 0;
+      third_sensor <= 3;
       enable_polynomial_finder <= 0;
       offset_finder_enable <= 0;
       pulse_id_0 <= 0;
       pulse_id_1 <= 0;
+      pulse_id_2 <= 0;
+      iteration_between_first_third <= 0;
       state <= WAITING_FOR_DATA;
     end
 
     default: ;
   endcase
+end
+
+reg [23:0] tmp_counter = 0;
+
+assign state_led = tmp_counter[5];
+
+always @ (posedge clk_96MHz) begin
+  if (state == POLYNOMIAL_IDENTIFICATION && polynomial == 0 && wait_for_module_activation == 0) begin
+    tmp_counter <= tmp_counter + 1;
+  end
 end
 
 endmodule // pulse_identifier

--- a/FPGA/receivers_top_level/receivers_top_level.lpf
+++ b/FPGA/receivers_top_level/receivers_top_level.lpf
@@ -8,21 +8,17 @@ IOBUF       PORT "tx"       IO_TYPE=LVCMOS33;
 LOCATE      COMP "state_led" SITE "U16";
 IOBUF       PORT "state_led" IO_TYPE=LVCMOS25;
 
-LOCATE      COMP "state_led1"  SITE "F2";
-IOBUF       PORT "state_led1"  IO_TYPE=LVCMOS33;
-LOCATE      COMP "state_led2"  SITE "F1";
-IOBUF       PORT "state_led2"  IO_TYPE=LVCMOS33;
-LOCATE      COMP "state_led3"  SITE "G3";
-IOBUF       PORT "state_led3"  IO_TYPE=LVCMOS33;
-LOCATE      COMP "state_led4"  SITE "H4";
-IOBUF       PORT "state_led4"  IO_TYPE=LVCMOS33;
+LOCATE      COMP "data_wire_0"  SITE "D20";
+IOBUF       PORT "data_wire_0" PULLMODE=NONE  IO_TYPE=LVCMOS33;
+LOCATE      COMP "data_wire_1"  SITE "A19";
+IOBUF       PORT "data_wire_1" PULLMODE=NONE  IO_TYPE=LVCMOS33;
+LOCATE      COMP "data_wire_2"  SITE "F2";
+IOBUF       PORT "data_wire_2" PULLMODE=NONE  IO_TYPE=LVCMOS33;
 
-LOCATE      COMP "data"  SITE "D20";
-IOBUF       PORT "data" PULLMODE=NONE  IO_TYPE=LVCMOS33;
-LOCATE      COMP "envelop"  SITE "B19";
-IOBUF       PORT "envelop" PULLMODE=NONE  IO_TYPE=LVCMOS33;
 
-LOCATE      COMP "data1"  SITE "A19";
-IOBUF       PORT "data1" PULLMODE=NONE  IO_TYPE=LVCMOS33;
-LOCATE      COMP "envelop1"  SITE "A18";
-IOBUF       PORT "envelop1" PULLMODE=NONE  IO_TYPE=LVCMOS33;
+LOCATE      COMP "envelop_wire_0"  SITE "B19";
+IOBUF       PORT "envelop_wire_0" PULLMODE=NONE  IO_TYPE=LVCMOS33;
+LOCATE      COMP "envelop_wire_1"  SITE "A18";
+IOBUF       PORT "envelop_wire_1" PULLMODE=NONE  IO_TYPE=LVCMOS33;
+LOCATE      COMP "envelop_wire_2"  SITE "F1";
+IOBUF       PORT "envelop_wire_2" PULLMODE=NONE  IO_TYPE=LVCMOS33;

--- a/FPGA/receivers_top_level/receivers_top_level.v
+++ b/FPGA/receivers_top_level/receivers_top_level.v
@@ -1,23 +1,19 @@
 `default_nettype none
 
 `include "../pll_module/pll_module.v"
-`include "../single_receiver_manager/single_receiver_manager.v"
-`include "../pulse_identifier/pulse_identifier.v"
 `include "../serial_transmitter/serial_transmitter.v"
-`include "../inout_face_manager/inout_face_manager.v"
+`include "../triad_manager/triad_manager.v"
 
 module receivers_top_level (
   input wire clk_25MHz,
-  inout wire envelop,
-  inout wire data,
-  inout wire envelop1,
-  inout wire data1,
+  inout wire envelop_wire_0,
+  inout wire envelop_wire_1,
+  inout wire envelop_wire_2,
+  inout wire data_wire_0,
+  inout wire data_wire_1,
+  inout wire data_wire_2,
   output wire tx,
-  output wire state_led,
-  output wire state_led1,
-  output wire state_led2,
-  output wire state_led3,
-  output wire state_led4
+  output wire state_led
   );
 
 wire clk_96MHz;
@@ -29,189 +25,54 @@ pll_module PLLs (
   .clk_12MHz (clk_12MHz)
   );
 
-reg [23:0] system_timestamp = 0;
+reg [23:0] sys_ts = 0;
 always @ (posedge clk_96MHz) begin
-  if (&system_timestamp) begin
-    system_timestamp <= 0;
+  if (&sys_ts) begin
+    sys_ts <= 0;
   end else begin
-    system_timestamp <= system_timestamp + 1;
+    sys_ts <= sys_ts + 1;
   end
 end
 
+wire reset_pulse_identifier_0;
+wire data_avl_0;
+wire [67:0] triad_data_0;
 
-
-// inout pin definition using primitive SB_IO
-wire envelop_output_enable;
-wire envelop_output;
-wire e_in_0;
-
-wire data_output_enable;
-wire data_output;
-wire d_in_0, d_in_1;
-
-// inout pin definition using primitive SB_IO
-wire envelop1_output_enable;
-wire envelop1_output;
-wire e1_in_0;
-
-wire data1_output_enable;
-wire data1_output;
-wire d1_in_0, d1_in_1;
-
-inout_face_manager INOUT0 (
+triad_manager TRIAD0 (
   .clk_96MHz (clk_96MHz),
-  .data_wire_0 (data),
-  .d_oe_0 (data_output_enable),
-  .d_out_0 (data_output),
-  .d_in_first_0 (d_in_0),
-  .d_in_second_0 (d_in_1),
-  .envelop_wire_0 (envelop),
-  .e_oe_0 (envelop_output_enable),
-  .e_out_0 (envelop_output),
-  .e_in_0 (e_in_0),
-  .data_wire_1 (data1),
-  .d_oe_1 (data1_output_enable),
-  .d_out_1 (data1_output),
-  .d_in_first_1 (d1_in_0),
-  .d_in_second_1 (d1_in_1),
-  .envelop_wire_1 (envelop1),
-  .e_oe_1 (envelop1_output_enable),
-  .e_out_1 (envelop1_output),
-  .e_in_1 (e1_in_0)
-  );
-
-/*
-SB_IO #(
-    .PIN_TYPE(6'b 1010_00),
-    .PULLUP(1'b 0)
-) envelop_io (
-    .PACKAGE_PIN(envelop),
-    .OUTPUT_ENABLE(envelop_output_enable),
-    .D_OUT_0(envelop_output),
-    .D_IN_0(e_in_0)
-);
-
-SB_IO #(
-    .PIN_TYPE(6'b 1010_00),
-    .PULLUP(1'b 0)
-) data_io (
-    .INPUT_CLK (clk_48MHz),
-    .PACKAGE_PIN(data),
-    .OUTPUT_ENABLE(data_output_enable),
-    .D_OUT_0(data_output),
-    .D_IN_0(d_in_0),
-    .D_IN_1(d_in_1),
-    .LATCH_INPUT_VALUE(1'b0)
-);
-*/
-
-wire reset;
-wire data_availible;
-wire [16:0] decoded_data;
-wire [23:0] timestamp_last_data;
-
-single_receiver_manager RECV0(
-  .clk_96MHz (clk_96MHz),
-  .e_in_0 (e_in_0),
-  .d_in_0 (d_in_0),
-  .d_in_1 (d_in_1),
-  .system_timestamp (system_timestamp),
-  .reset (reset_bmc_decoder_0),
-  .envelop_output_enable (envelop_output_enable),
-  .envelop_output (envelop_output),
-  .data_output_enable (data_output_enable),
-  .data_output (data_output),
-  .data_availible (data_availible),
-  .decoded_data (decoded_data),
-  .timestamp_last_data (timestamp_last_data),
+  .envelop_wire_0 (envelop_wire_0),
+  .envelop_wire_1 (envelop_wire_1),
+  .envelop_wire_2 (envelop_wire_2),
+  .data_wire_0 (data_wire_0),
+  .data_wire_1 (data_wire_1),
+  .data_wire_2 (data_wire_2),
+  .sys_ts (sys_ts),
+  .reset_pulse_identifier (reset_pulse_identifier_0),
+  .data_avl (data_avl_0),
+  .triad_data (triad_data_0),
   .state_led (state_led)
   );
 
-single_receiver_manager RECV1(
-  .clk_96MHz (clk_96MHz),
-  .e_in_0 (e1_in_0),
-  .d_in_0 (d1_in_0),
-  .d_in_1 (d1_in_1),
-  .system_timestamp (system_timestamp),
-  .reset (reset_bmc_decoder_1),
-  .envelop_output_enable (envelop1_output_enable),
-  .envelop_output (envelop1_output),
-  .data_output_enable (data1_output_enable),
-  .data_output (data1_output),
-  .data_availible (data1_availible),
-  .decoded_data (decoded_data1),
-  .timestamp_last_data (timestamp_last_data1),
-  .state_led (state_led1)
-  );
-
-
-
-
-
-
-/*
-SB_IO #(
-    .PIN_TYPE(6'b 1010_00),
-    .PULLUP(1'b 0)
-) envelop1_io (
-    .PACKAGE_PIN(envelop1),
-    .OUTPUT_ENABLE(envelop1_output_enable),
-    .D_OUT_0(envelop1_output),
-    .D_IN_0(e1_in_0)
-);
-
-SB_IO #(
-    .PIN_TYPE(6'b 1010_00),
-    .PULLUP(1'b 0)
-) data1_io (
-    .INPUT_CLK (clk_48MHz),
-    .PACKAGE_PIN(data1),
-    .OUTPUT_ENABLE(data1_output_enable),
-    .D_OUT_0(data1_output),
-    .D_IN_0(d1_in_0),
-    .D_IN_1(d1_in_1),
-    .LATCH_INPUT_VALUE(1'b0)
-);
-*/
-
-wire reset1;
-wire data1_availible;
-wire [16:0] decoded_data1;
-wire [23:0] timestamp_last_data1;
-
-wire reset_pulse_identifier;
-wire [16:0] pulse_id_0;
-wire [16:0] pulse_id_1;
-wire [16:0] polynomial;
-wire reset_bmc_decoder_0;
-wire reset_bmc_decoder_1;
-wire pulse_identifier_ready;
-
-pulse_identifier PULSE_IDENTIFIER0 (
-  .clk_96MHz (clk_96MHz),
-  .data_availible (data_availible),
-  .data_availible1 (data1_availible),
-  .ts_data (timestamp_last_data),
-  .ts_data1 (timestamp_last_data1),
-  .decoded_data (decoded_data),
-  .decoded_data1 (decoded_data1),
-  .reset (reset_pulse_identifier),
-  .pulse_id_0 (pulse_id_0),
-  .pulse_id_1 (pulse_id_1),
-  .polynomial (polynomial),
-  .reset_bmc_decoder_0 (reset_bmc_decoder_0),
-  .reset_bmc_decoder_1 (reset_bmc_decoder_1),
-  .ready (pulse_identifier_ready)
-  );
 
 serial_transmitter UART (
   .clk_12MHz (clk_12MHz),
-  .data_availible (pulse_identifier_ready),
-  .pulse_id_0 (pulse_id_0),
-  .pulse_id_1 (pulse_id_1),
-  .polynomial (polynomial),
+  .data_availible (data_avl_0),
+  .triad_data (triad_data_0),
   .tx (tx),
-  .reset_pulse_identifier (reset_pulse_identifier)
+  .reset_pulse_identifier (reset_pulse_identifier_0)
   );
 
+//assign state_led = sys_ts[23];
+
 endmodule // receivers_top_level
+
+/*
+LOCATE      COMP "state_led1"  SITE "F2";
+IOBUF       PORT "state_led1"  IO_TYPE=LVCMOS33;
+LOCATE      COMP "state_led2"  SITE "F1";
+IOBUF       PORT "state_led2"  IO_TYPE=LVCMOS33;
+LOCATE      COMP "state_led3"  SITE "G3";
+IOBUF       PORT "state_led3"  IO_TYPE=LVCMOS33;
+LOCATE      COMP "state_led4"  SITE "H4";
+IOBUF       PORT "state_led4"  IO_TYPE=LVCMOS33;
+*/

--- a/FPGA/receivers_top_level/receivers_top_level.v
+++ b/FPGA/receivers_top_level/receivers_top_level.v
@@ -62,17 +62,4 @@ serial_transmitter UART (
   .reset_pulse_identifier (reset_pulse_identifier_0)
   );
 
-//assign state_led = sys_ts[23];
-
 endmodule // receivers_top_level
-
-/*
-LOCATE      COMP "state_led1"  SITE "F2";
-IOBUF       PORT "state_led1"  IO_TYPE=LVCMOS33;
-LOCATE      COMP "state_led2"  SITE "F1";
-IOBUF       PORT "state_led2"  IO_TYPE=LVCMOS33;
-LOCATE      COMP "state_led3"  SITE "G3";
-IOBUF       PORT "state_led3"  IO_TYPE=LVCMOS33;
-LOCATE      COMP "state_led4"  SITE "H4";
-IOBUF       PORT "state_led4"  IO_TYPE=LVCMOS33;
-*/

--- a/FPGA/single_receiver_manager/single_receiver_manager.v
+++ b/FPGA/single_receiver_manager/single_receiver_manager.v
@@ -8,7 +8,7 @@ module single_receiver_manager (
   input wire e_in_0,
   input wire d_in_0,
   input wire d_in_1,
-  input wire [23:0] system_timestamp,
+  input wire [23:0] sys_ts,
   input wire reset,
 
   output reg envelop_output_enable,
@@ -19,12 +19,12 @@ module single_receiver_manager (
 
   output wire data_availible,
   output wire [16:0] decoded_data,
-  output wire [23:0] timestamp_last_data,
+  output wire [23:0] ts_last_data,
 
   output wire state_led
   );
 
-reg configured;
+wire configured;
 
 ts4231_configurator TS4231_CONFIGURATOR (
   .clk_96MHz (clk_96MHz),
@@ -44,11 +44,11 @@ bmc_decoder #(.bit_considered (17))
     .d_in_1 (d_in_1),
     .e_in_0 (e_in_0),
     .enabled (configured),
-    .system_timestamp (system_timestamp),
+    .sys_ts (sys_ts),
     .reset (reset),
     .decoded_data (decoded_data),
     .data_availible (data_availible),
-    .timestamp_last_data (timestamp_last_data),
+    .ts_last_data (ts_last_data),
     .state_led (state_led)
     );
 

--- a/FPGA/triad_manager/triad_manager.v
+++ b/FPGA/triad_manager/triad_manager.v
@@ -199,7 +199,4 @@ always @ (posedge clk_96MHz) begin
   end
 end
 
-//assign state_led = pulse_identifier_ready;
-
-
 endmodule // triad_manager

--- a/FPGA/triad_manager/triad_manager.v
+++ b/FPGA/triad_manager/triad_manager.v
@@ -1,0 +1,205 @@
+`default_nettype none
+
+`include "../inout_face_manager/inout_face_manager.v"
+`include "../single_receiver_manager/single_receiver_manager.v"
+`include "../pulse_identifier/pulse_identifier.v"
+
+module triad_manager (
+  input wire clk_96MHz,
+
+  inout wire envelop_wire_0,
+  inout wire envelop_wire_1,
+  inout wire envelop_wire_2,
+
+  inout wire data_wire_0,
+  inout wire data_wire_1,
+  inout wire data_wire_2,
+
+  input wire [23:0] sys_ts,
+  input wire reset_pulse_identifier,
+
+  output reg data_avl,
+  output reg [67:0] triad_data,
+
+  output wire state_led
+  );
+wire state_led1;
+wire state_led2;
+wire state_led3;
+
+wire d_0_oe;
+wire d_0_out;
+wire d_0_in_0;
+wire d_0_in_1;
+
+wire d_1_oe;
+wire d_1_out;
+wire d_1_in_0;
+wire d_1_in_1;
+
+wire d_2_oe;
+wire d_2_out;
+wire d_2_in_0;
+wire d_2_in_1;
+
+wire e_0_oe;
+wire e_0_out;
+wire e_0_in;
+
+wire e_1_oe;
+wire e_1_out;
+wire e_1_in;
+
+wire e_2_oe;
+wire e_2_out;
+wire e_2_in;
+
+inout_face_manager INOUT0 (
+  .clk_96MHz (clk_96MHz),
+
+  .data_wire_0 (data_wire_0),
+  .d_0_oe (d_0_oe),
+  .d_0_out (d_0_out),
+  .d_0_in_0 (d_0_in_0),
+  .d_0_in_1 (d_0_in_1),
+
+  .data_wire_1 (data_wire_1),
+  .d_1_oe (d_1_oe),
+  .d_1_out (d_1_out),
+  .d_1_in_0 (d_1_in_0),
+  .d_1_in_1 (d_1_in_1),
+
+  .data_wire_2 (data_wire_2),
+  .d_2_oe (d_2_oe),
+  .d_2_out (d_2_out),
+  .d_2_in_0 (d_2_in_0),
+  .d_2_in_1 (d_2_in_1),
+
+  .envelop_wire_0 (envelop_wire_0),
+  .e_0_oe (e_0_oe),
+  .e_0_out (e_0_out),
+  .e_0_in (e_0_in),
+
+  .envelop_wire_1 (envelop_wire_1),
+  .e_1_oe (e_1_oe),
+  .e_1_out (e_1_out),
+  .e_1_in (e_1_in),
+
+  .envelop_wire_2 (envelop_wire_2),
+  .e_2_oe (e_2_oe),
+  .e_2_out (e_2_out),
+  .e_2_in (e_2_in)
+  );
+
+wire reset_bmc_decoder_0;
+wire data_avl_0;
+wire [16:0] decoded_data_0;
+wire [23:0] ts_last_data_0;
+
+single_receiver_manager RECV0 (
+  .clk_96MHz (clk_96MHz),
+  .e_in_0 (e_0_in),
+  .d_in_0 (d_0_in_0),
+  .d_in_1 (d_0_in_1),
+  .sys_ts (sys_ts),
+  .reset (reset_bmc_decoder_0),
+  .envelop_output_enable (e_0_oe),
+  .envelop_output (e_0_out),
+  .data_output_enable (d_0_oe),
+  .data_output (d_0_out),
+  .data_availible (data_avl_0),
+  .decoded_data (decoded_data_0),
+  .ts_last_data (ts_last_data_0),
+  .state_led (state_led1)
+  );
+
+wire reset_bmc_decoder_1;
+wire data_avl_1;
+wire [16:0] decoded_data_1;
+wire [23:0] ts_last_data_1;
+
+single_receiver_manager RECV1 (
+  .clk_96MHz (clk_96MHz),
+  .e_in_0 (e_1_in),
+  .d_in_0 (d_1_in_0),
+  .d_in_1 (d_1_in_1),
+  .sys_ts (sys_ts),
+  .reset (reset_bmc_decoder_1),
+  .envelop_output_enable (e_1_oe),
+  .envelop_output (e_1_out),
+  .data_output_enable (d_1_oe),
+  .data_output (d_1_out),
+  .data_availible (data_avl_1),
+  .decoded_data (decoded_data_1),
+  .ts_last_data (ts_last_data_1),
+  .state_led (state_led2)
+  );
+
+wire reset_bmc_decoder_2;
+wire data_avl_2;
+wire [16:0] decoded_data_2;
+wire [23:0] ts_last_data_2;
+
+single_receiver_manager RECV2 (
+  .clk_96MHz (clk_96MHz),
+  .e_in_0 (e_2_in),
+  .d_in_0 (d_2_in_0),
+  .d_in_1 (d_2_in_1),
+  .sys_ts (sys_ts),
+  .reset (reset_bmc_decoder_2),
+  .envelop_output_enable (e_2_oe),
+  .envelop_output (e_2_out),
+  .data_output_enable (d_2_oe),
+  .data_output (d_2_out),
+  .data_availible (data_avl_2),
+  .decoded_data (decoded_data_2),
+  .ts_last_data (ts_last_data_2),
+  .state_led (state_led3)
+  );
+
+wire [16:0] pulse_id_0;
+wire [16:0] pulse_id_1;
+wire [16:0] pulse_id_2;
+wire [16:0] polynomial;
+wire pulse_identifier_ready;
+
+pulse_identifier PULSE_IDENTIFIER0 (
+  .clk_96MHz (clk_96MHz),
+  .data_availible (data_avl_0),
+  .data_availible1 (data_avl_1),
+  .data_availible2 (data_avl_2),
+  .ts_data (ts_last_data_0),
+  .ts_data1 (ts_last_data_1),
+  .ts_data2 (ts_last_data_2),
+  .decoded_data (decoded_data_0),
+  .decoded_data1 (decoded_data_1),
+  .decoded_data2 (decoded_data_2),
+  .reset (reset_pulse_identifier),
+  .pulse_id_0 (pulse_id_0),
+  .pulse_id_1 (pulse_id_1),
+  .pulse_id_2 (pulse_id_2),
+  .polynomial (polynomial),
+  .reset_bmc_decoder_0 (reset_bmc_decoder_0),
+  .reset_bmc_decoder_1 (reset_bmc_decoder_1),
+  .reset_bmc_decoder_2 (reset_bmc_decoder_2),
+  .ready (pulse_identifier_ready),
+  .state_led (state_led),
+  .sys_ts (sys_ts)
+  );
+
+
+always @ (posedge clk_96MHz) begin
+  if (pulse_identifier_ready) begin
+    data_avl <= 1;
+    triad_data <= {
+      pulse_id_2, pulse_id_1, pulse_id_0, polynomial
+    };
+  end else begin
+    data_avl <= 0;
+  end
+end
+
+//assign state_led = pulse_identifier_ready;
+
+
+endmodule // triad_manager


### PR DESCRIPTION
# Purpose of this PR

In order to be able to manage more than 2 sensors, a reformatting of the architecture happened.

# What has been done ?

Here's the new architecture of the whole design:
```
Top module:  \receivers_top_level
Used module:     \serial_transmitter
Used module:         \uart_tx
Used module:             \baudgen
Used module:     \triad_manager
Used module:         \pulse_identifier
Used module:             \offset_finder
Used module:                 \lfsr
Used module:             \polynomial_finder
Used module:         \single_receiver_manager
Used module:             \bmc_decoder
Used module:             \ts4231_configurator
Used module:                 \ts4231Configurator
Used module:         \inout_face_manager
Used module:     \pll_module
Used module:         \pll_module_96_12
Used module:         \pll_module_100
```
*Extracted from yosys synthesis*

# Problem raised

A major problem has been raised during the validation of the design:
**The BMC_decoder module isn't that good**. As we want the more data as possible, a new BMC_decoder and pulse_identifier design including RAM is in WIP. 