### PR TITLE
FPGA fixes batch

### DIFF
--- a/FPGA/bmc_decoder/bmc_decoder.v
+++ b/FPGA/bmc_decoder/bmc_decoder.v
@@ -48,7 +48,7 @@ always @ (posedge clk_96MHz) begin
       SAMPLE: begin
         if (tick_counter > timeout_counter) begin
           state <= ERROR;
-        end else if (d_in_0 != d_in_1 && tick_counter > too_fast_counter) begin
+        end else if (d_in_0 != d_in_1 && tick_counter > too_fast_counter && !e_in_0) begin
           if (tick_counter <= fast_counter) begin
             state <= FAST_STATE;
           end else if (tick_counter <= timeout_counter && tick_counter > slow_counter) begin

--- a/FPGA/lfsr/lfsr.v
+++ b/FPGA/lfsr/lfsr.v
@@ -1,7 +1,7 @@
 `default_nettype none
 
 module lfsr (
-  input wire clk_96MHz,
+  input wire clk_72MHz,
   input wire [16:0] polynomial,
   input wire [16:0] start_data,
   input wire enable,
@@ -17,7 +17,7 @@ localparam  ITERATE = 2;
 reg [1:0] state = IDLE;
 reg binary_bit;
 
-always @ (posedge clk_96MHz) begin
+always @ (posedge clk_72MHz) begin
   case (state)
     IDLE: begin
       if (enable == 1) begin

--- a/FPGA/offset_finder/offset_finder.v
+++ b/FPGA/offset_finder/offset_finder.v
@@ -2,7 +2,7 @@
 `include "../lfsr/lfsr.v"
 
 module offset_finder (
-  input wire clk_96MHz,
+  input wire clk_72MHz,
   input wire [16:0] polynomial,
   input wire [16:0] data,
   input wire enable,
@@ -38,7 +38,7 @@ wire [16:0] iteration_number_3;
 reg enable_LFSRs = 0;
 
 lfsr LFSR_0 (
-  .clk_96MHz (clk_96MHz),
+  .clk_72MHz (clk_72MHz),
   .polynomial (polynomial),
   .start_data (17'h1),
   .enable (enable_LFSRs),
@@ -47,7 +47,7 @@ lfsr LFSR_0 (
   );
 
 lfsr LFSR_1 (
-  .clk_96MHz (clk_96MHz),
+  .clk_72MHz (clk_72MHz),
   .polynomial (polynomial),
   .start_data (start_data_1),
   .enable (enable_LFSRs),
@@ -56,7 +56,7 @@ lfsr LFSR_1 (
   );
 
 lfsr LFSR_2 (
-  .clk_96MHz (clk_96MHz),
+  .clk_72MHz (clk_72MHz),
   .polynomial (polynomial),
   .start_data (start_data_2),
   .enable (enable_LFSRs),
@@ -65,7 +65,7 @@ lfsr LFSR_2 (
   );
 
 lfsr LFSR_3 (
-  .clk_96MHz (clk_96MHz),
+  .clk_72MHz (clk_72MHz),
   .polynomial (polynomial),
   .start_data (start_data_3),
   .enable (enable_LFSRs),
@@ -74,7 +74,7 @@ lfsr LFSR_3 (
   );
 
 
-always @ (posedge clk_96MHz) begin
+always @ (posedge clk_72MHz) begin
   case (state)
     IDLE: begin
       if (enable == 1) begin

--- a/FPGA/pll_module/pll_module.v
+++ b/FPGA/pll_module/pll_module.v
@@ -1,12 +1,13 @@
 `default_nettype none
 
 `include "../pll_module/pll_module_100.v"
-`include "../pll_module/pll_module_96_12.v"
+`include "../pll_module/pll_module_96_12_72.v"
 
 module pll_module(
 	input wire clk_25MHz,
 	output wire clk_96MHz,
-	output wire clk_12MHz
+	output wire clk_12MHz,
+	output wire clk_72MHz
 	);
 
 wire clk_100MHz;
@@ -19,10 +20,11 @@ pll_module_100 PLL0(
 	.locked (locked_pll_0)
 	);
 
-pll_module_96_12 PLL1(
+pll_module_96_12_72 PLL1(
 	.clk_100MHz (clk_100MHz),
 	.clk_96MHz (clk_96MHz),
 	.clk_12MHz (clk_12MHz),
+	.clk_72MHz (clk_72MHz),
 	.locked (locked_pll_1)
 	);
 

--- a/FPGA/pll_module/pll_module_96_12_72.v
+++ b/FPGA/pll_module/pll_module_96_12_72.v
@@ -2,16 +2,18 @@
 // diamond 3.8-3.9 is untested
 // diamond 3.10 or higher is likely to abort with error about unable to use feedback signal
 // cause of this could be from wrong CPHASE/FPHASE parameters
-module pll_module_96_12
+module pll_module_96_12_72
 (
     input clk_100MHz, // 100 MHz, 0 deg
     output clk_96MHz, // 96 MHz, 0 deg
     output clk_12MHz, // 12 MHz, 0 deg
+    output clk_72MHz, // 72 MHz, 0 deg
     output locked
 );
 (* FREQUENCY_PIN_CLKI="100" *)
 (* FREQUENCY_PIN_CLKOP="96" *)
 (* FREQUENCY_PIN_CLKOS="12" *)
+(* FREQUENCY_PIN_CLKOS2="72" *)
 (* ICP_CURRENT="12" *) (* LPF_RESISTOR="8" *) (* MFG_ENABLE_FILTEROPAMP="1" *) (* MFG_GMCREF_SEL="2" *)
 EHXPLLL #(
         .PLLRST_ENA("DISABLED"),
@@ -31,6 +33,10 @@ EHXPLLL #(
         .CLKOS_DIV(48),
         .CLKOS_CPHASE(2),
         .CLKOS_FPHASE(0),
+        .CLKOS2_ENABLE("ENABLED"),
+        .CLKOS2_DIV(8),
+        .CLKOS2_CPHASE(2),
+        .CLKOS2_FPHASE(0),
         .FEEDBK_PATH("CLKOP"),
         .CLKFB_DIV(24)
     ) pll_i (
@@ -39,6 +45,7 @@ EHXPLLL #(
         .CLKI(clk_100MHz),
         .CLKOP(clk_96MHz),
         .CLKOS(clk_12MHz),
+        .CLKOS2(clk_72MHz),
         .CLKFB(clk_96MHz),
         .CLKINTFB(),
         .PHASESEL0(1'b0),

--- a/FPGA/pll_module/pll_module_sim.v
+++ b/FPGA/pll_module/pll_module_sim.v
@@ -3,21 +3,45 @@
 module pll_module_sim(
 	input wire clk_25MHz,
 	output reg clk_96MHz,
-	output reg clk_12MHz
+	output reg clk_12MHz,
+	output reg clk_72MHz
 	);
 
-reg [3:0] counter = 0;
+reg [4:0] counter_12 = 0;
+reg [2:0] counter_72 = 0;
+reg [1:0] counter_96 = 0;
+
 initial begin
 	clk_96MHz = 0;
 	clk_12MHz = 0;
+	clk_72MHz = 0;
 end
 
-always @ ( clk_25MHz) begin
-	if (~|counter) begin
-		clk_12MHz <= ~clk_12MHz;
+always @ (clk_25MHz) begin
+	if (counter_96 == 2) begin
+		clk_96MHz <= ~clk_96MHz;
+		counter_96 <= 0;
+	end else begin
+		counter_96 <= counter_96 + 1;
 	end
-	counter <= counter + 1;
-	clk_96MHz <= ~clk_96MHz;
+end
+
+always @ (clk_25MHz) begin
+	if (counter_72 == 3) begin
+		clk_72MHz <= ~clk_72MHz;
+		counter_72 <= 0;
+	end else begin
+		counter_72 <= counter_72 + 1;
+	end
+end
+
+always @ (clk_25MHz) begin
+	if (counter_12 == 23) begin
+		clk_12MHz <= ~clk_12MHz;
+		counter_12 <= 0;
+	end else begin
+		counter_12 <= counter_12 + 1;
+	end
 end
 
 endmodule

--- a/FPGA/polynomial_finder/polynomial_finder.v
+++ b/FPGA/polynomial_finder/polynomial_finder.v
@@ -10,8 +10,7 @@ module polynomial_finder (
 
   output reg [16:0] polynomial,
   output reg [16:0] iteration_number,
-  output reg ready,
-  output wire state_led
+  output reg ready
   );
 
 parameter iteration_approx = 2;
@@ -114,22 +113,6 @@ always @ (posedge clk_72MHz) begin
 
     default: ;
   endcase
-end
-
-reg [3:0] prev_state;
-
-always @ (posedge clk_72MHz) begin
-  prev_state <= state;
-end
-
-reg [23:0] tmp_counter = 23'd0;
-
-assign state_led = tmp_counter[23];
-
-always @ (posedge clk_72MHz) begin
-  if (state != IDLE && state != WAIT_FOR_RESET && enable == 0) begin
-    tmp_counter <= tmp_counter + 1;
-  end
 end
 
 endmodule // polynomial_finder

--- a/FPGA/polynomial_finder/polynomial_finder.v
+++ b/FPGA/polynomial_finder/polynomial_finder.v
@@ -76,13 +76,18 @@ always @ (posedge clk_96MHz) begin
 
     RUN_LFSR: begin
       enable_LFSRs <= 1;
-      if (iteration_number_1D258 > (estimated_iteration - iteration_approx - 1)) begin
+      if (~enable) begin
+        state <= WAIT_FOR_RESET;
+      end else if (iteration_number_1D258 > (estimated_iteration - iteration_approx - 1)) begin
         state <= IDENTIFY_POLYNOMIAL;
       end
     end
 
     IDENTIFY_POLYNOMIAL: begin
-      if (value_1D258 == decoded_data1) begin
+      if (~enable) begin
+        enable_LFSRs <= 0;
+        state <= WAIT_FOR_RESET;
+      end else if (value_1D258 == decoded_data1) begin
         polynomial <= 17'h1d258;
         iteration_number <= iteration_number_1D258;
         enable_LFSRs <= 0;

--- a/FPGA/polynomial_manager/polynomial_manager.v
+++ b/FPGA/polynomial_manager/polynomial_manager.v
@@ -18,8 +18,7 @@ module polynomial_manager (
   output reg [16:0] iteration_number,
   output reg [16:0] first_data,
   output reg [23:0] ts_first_data,
-  output reg ready,
-  output wire state_led
+  output reg ready
   );
 
 parameter init_array_file = "../polynomial_manager/init_array.list";
@@ -92,8 +91,7 @@ polynomial_finder POLY_FINDERS0 (
 
   .polynomial (polynomial_0),
   .iteration_number (iteration_number_0),
-  .ready (polynomial_finder_ready_0),
-  .state_led (state_led)
+  .ready (polynomial_finder_ready_0)
   );
 
 wire [16:0] polynomial_1;
@@ -311,23 +309,6 @@ always @ (posedge clk_72MHz) begin
       state <= IDLE;
     end
   endcase
-end
-
-
-reg [3:0] prev_state;
-
-always @ (posedge clk_72MHz) begin
-  prev_state <= state;
-end
-
-reg [23:0] tmp_counter = 23'd0;
-
-//assign state_led = tmp_counter[6];
-
-always @ (posedge clk_72MHz) begin
-  if (state == WAIT_FOR_RESET && timeout_counter > timeout_ticks && prev_state == RUN_POLYNOMIAL_FINDERS) begin
-    tmp_counter <= tmp_counter + 1;
-  end
 end
 
 endmodule // polynomial_manager

--- a/FPGA/pulse_identifier/pulse_identifier.v
+++ b/FPGA/pulse_identifier/pulse_identifier.v
@@ -24,8 +24,7 @@ module pulse_identifier (
   output reg [7:0] block_wanted_number_1,
   output reg [7:0] block_wanted_number_2,
 
-  input wire [23:0] sys_ts,
-  output wire state_led
+  input wire [23:0] sys_ts
   );
 
 parameter timeout_ticks = 72000; //~1ms in a 72MHz clock frequency
@@ -144,8 +143,7 @@ polynomial_manager POLY_MANAGER(
   .iteration_number (iteration_between_first_second),
   .first_data (first_data),
   .ts_first_data (ts_first_data),
-  .ready (polynomial_manager_ready),
-  .state_led (state_led)
+  .ready (polynomial_manager_ready)
   );
 
 reg offset_finder_enable;
@@ -163,13 +161,10 @@ offset_finder OFFSET_FINDER0(
 
 always @ (posedge clk_72MHz) begin
   if (third_sensor == 0 && (|avl_blocks_nb_0 && ts_third_data == 0) && waiting_timer != timeout_ticks) begin
-    //data_spotted[0] <= 1;
     ts_third_data <= sys_ts;
   end else if (third_sensor == 1 && (|avl_blocks_nb_1 && ts_third_data == 0) && waiting_timer != timeout_ticks) begin
-    //data_spotted[1] <= 1;
     ts_third_data <= sys_ts;
   end else if (third_sensor == 2 && (|avl_blocks_nb_2 && ts_third_data == 0) && waiting_timer != timeout_ticks) begin
-    //data_spotted[2] <= 1;
     ts_third_data <= sys_ts;
   end else if (third_sensor == 3) begin
     ts_third_data <= 0;
@@ -355,24 +350,6 @@ always @ (posedge clk_72MHz) begin
 
     default: ;
   endcase
-end
-
-reg [3:0] prev_state;
-
-always @ (posedge clk_72MHz) begin
-  prev_state <= state;
-end
-
-reg [23:0] tmp_counter = 23'd0;
-
-//assign state_led = tmp_counter[6];
-
-always @ (posedge clk_72MHz) begin
-  if (state == WAIT_FOR_ALL_RAM_DUMP && prev_state == OFFSET_IDENTIFICATION) begin
-    tmp_counter <= tmp_counter + 1;
-  end/* else begin
-    tmp_counter <= 0;
-  end*/
 end
 
 endmodule // pulse_identifier

--- a/FPGA/ram_decoded/ram_decoded.v
+++ b/FPGA/ram_decoded/ram_decoded.v
@@ -10,8 +10,7 @@ module ram_decoded (
   output reg [40:0] block_wanted,
   output reg data_ready,
   output reg reset_bmc_decoder,
-  output reg [7:0] avl_blocks_nb,
-  output wire state_led
+  output reg [7:0] avl_blocks_nb
   );
 
 parameter dump_ticks = 96000; //1ms in a 96MHz clock
@@ -123,22 +122,6 @@ always @ (posedge clk_96MHz) begin
       end
     end
   endcase
-end
-
-reg [3:0] prev_state;
-
-always @ (posedge clk_96MHz) begin
-  prev_state <= state_2;
-end
-
-reg [23:0] tmp_counter = 23'd0;
-
-assign state_led = tmp_counter[6];
-
-always @ (posedge clk_96MHz) begin
-  if (state_2 == FETCHING_DATA && block_wanted_number > avl_blocks_nb) begin
-    tmp_counter <= tmp_counter + 1;
-  end
 end
 
 endmodule // ram_decoded

--- a/FPGA/receivers_top_level/receivers_top_level.v
+++ b/FPGA/receivers_top_level/receivers_top_level.v
@@ -12,8 +12,7 @@ module receivers_top_level (
   inout wire data_wire_0,
   inout wire data_wire_1,
   inout wire data_wire_2,
-  output wire tx,
-  output wire state_led
+  output wire tx
   );
 
 wire clk_96MHz;
@@ -52,8 +51,7 @@ triad_manager TRIAD0 (
   .sys_ts (sys_ts),
   .reset_parser (reset_parser_0),
   .data_avl (data_avl_0),
-  .sensor_iterations (sensor_iterations_0),
-  .state_led (state_led)
+  .sensor_iterations (sensor_iterations_0)
   );
 
 

--- a/FPGA/receivers_top_level/receivers_top_level.v
+++ b/FPGA/receivers_top_level/receivers_top_level.v
@@ -18,11 +18,13 @@ module receivers_top_level (
 
 wire clk_96MHz;
 wire clk_12MHz;
+wire clk_72MHz;
 
 pll_module PLLs (
   .clk_25MHz (clk_25MHz),
   .clk_96MHz (clk_96MHz),
-  .clk_12MHz (clk_12MHz)
+  .clk_12MHz (clk_12MHz),
+  .clk_72MHz (clk_72MHz)
   );
 
 reg [23:0] sys_ts = 0;
@@ -34,12 +36,13 @@ always @ (posedge clk_96MHz) begin
   end
 end
 
-wire reset_pulse_identifier_0;
+wire reset_parser_0;
 wire data_avl_0;
-wire [67:0] triad_data_0;
+wire [101:0] sensor_iterations_0;
 
 triad_manager TRIAD0 (
   .clk_96MHz (clk_96MHz),
+  .clk_72MHz (clk_72MHz),
   .envelop_wire_0 (envelop_wire_0),
   .envelop_wire_1 (envelop_wire_1),
   .envelop_wire_2 (envelop_wire_2),

--- a/FPGA/receivers_top_level_sim/receivers_top_level_sim.v
+++ b/FPGA/receivers_top_level_sim/receivers_top_level_sim.v
@@ -17,11 +17,13 @@ module receivers_top_level_sim (
 wire state_led;
 wire clk_96MHz;
 wire clk_12MHz;
+wire clk_72MHz;
 
 pll_module_sim PLLs (
   .clk_25MHz (clk_25MHz),
   .clk_96MHz (clk_96MHz),
-  .clk_12MHz (clk_12MHz)
+  .clk_12MHz (clk_12MHz),
+  .clk_72MHz (clk_72MHz)
   );
 
 reg [23:0] sys_ts = 0;
@@ -39,6 +41,7 @@ wire [101:0] sensor_iterations_0;
 
 triad_manager_sim TRIAD0 (
   .clk_96MHz (clk_96MHz),
+  .clk_72MHz (clk_72MHz),
   .envelop_wire_0 (envelop_wire_0),
   .envelop_wire_1 (envelop_wire_1),
   .envelop_wire_2 (envelop_wire_2),

--- a/FPGA/receivers_top_level_sim/receivers_top_level_sim_tb.gtkw
+++ b/FPGA/receivers_top_level_sim/receivers_top_level_sim_tb.gtkw
@@ -1,17 +1,14 @@
 [*]
 [*] GTKWave Analyzer v3.3.103 (w)1999-2019 BSI
-[*] Sun Dec 26 00:39:53 2021
+[*] Sat Jan  8 18:36:51 2022
 [*]
-[dumpfile] "/home/phileas/ViveTracker/FPGA/receivers_top_level_sim/receivers_top_level_sim_tb.vcd"
-[dumpfile_mtime] "Sun Dec 26 00:37:02 2021"
-[dumpfile_size] 128058881
+[dumpfile] "(null)"
 [savefile] "/home/phileas/ViveTracker/FPGA/receivers_top_level_sim/receivers_top_level_sim_tb.gtkw"
-[timestart] 557527
-[size] 1335 1043
+[timestart] 0
+[size] 1920 1043
 [pos] -1 -1
-*-6.422216 557663 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+*-24.422216 999 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
 [treeopen] receivers_top_level_sim_tb.
-[treeopen] receivers_top_level_sim_tb.dut.
 [treeopen] receivers_top_level_sim_tb.dut.TRIAD0.
 [treeopen] receivers_top_level_sim_tb.dut.TRIAD0.PULSE_IDENTIFIER0.POLY_MANAGER.
 [treeopen] receivers_top_level_sim_tb.dut.TRIAD0.PULSE_IDENTIFIER0.POLY_MANAGER.POLY_FINDERS0.
@@ -25,6 +22,10 @@
 [sst_vpaned_height] 308
 @28
 receivers_top_level_sim_tb.dut.clk_96MHz
+@29
+receivers_top_level_sim_tb.dut.clk_72MHz
+@28
+receivers_top_level_sim_tb.dut.clk_12MHz
 @200
 -
 -BMC_decoder_0
@@ -180,9 +181,8 @@ receivers_top_level_sim_tb.dut.TRIAD0.PULSE_IDENTIFIER0.POLY_MANAGER.polynomial_
 receivers_top_level_sim_tb.dut.TRIAD0.PULSE_IDENTIFIER0.POLY_MANAGER.polynomial[16:0]
 @1001200
 -group_end
-@201
--
 @200
+-
 -POLY_FINDER_0
 @24
 receivers_top_level_sim_tb.dut.TRIAD0.PULSE_IDENTIFIER0.POLY_MANAGER.POLY_FINDERS0.estimated_iteration[16:0]

--- a/FPGA/receivers_top_level_sim/receivers_top_level_sim_tb.v
+++ b/FPGA/receivers_top_level_sim/receivers_top_level_sim_tb.v
@@ -1,8 +1,9 @@
+`timescale 1s/ 1ms
 `include "../uart_tx_module/baudgen.vh"
 
 module receivers_top_level_sim_tb ();
 
-localparam  CLOCK_TICK = 1; //((1/(96))/2) * PRESCALER;
+localparam  CLOCK_TICK = 0.999; //((1/(96))/2) * PRESCALER;
 
 localparam  CLOCK_PERIOD = 2*CLOCK_TICK;
 
@@ -83,7 +84,7 @@ task random_deviation_state;
   end
 endtask
 
-always #1 clk <= ~clk;
+always #0.333 clk <= ~clk;
 
 reg [1:0] data_wire_used = 0;
 reg wire_data_changing = 0;

--- a/FPGA/single_receiver_manager/single_receiver_manager.v
+++ b/FPGA/single_receiver_manager/single_receiver_manager.v
@@ -21,8 +21,6 @@ module single_receiver_manager (
   output wire [40:0] block_wanted,
   output wire data_ready,
   output wire [7:0] avl_blocks_nb,
-
-  output wire state_led
   );
 
 wire configured;
@@ -67,18 +65,7 @@ ram_decoded RAM(
   .block_wanted (block_wanted),
   .data_ready (data_ready),
   .reset_bmc_decoder (reset),
-  .avl_blocks_nb (avl_blocks_nb),
-  .state_led (state_led)
+  .avl_blocks_nb (avl_blocks_nb)
   );
-
-reg [23:0] tmp_counter = 0;
-
-//assign state_led = tmp_counter[23];
-
-always @ (posedge clk_96MHz) begin
-  if (avl_blocks_nb == 0) begin
-    tmp_counter <= tmp_counter + 1;
-  end
-end
 
 endmodule // single_receiver_manager

--- a/FPGA/single_receiver_manager/single_receiver_manager.v
+++ b/FPGA/single_receiver_manager/single_receiver_manager.v
@@ -67,7 +67,8 @@ ram_decoded RAM(
   .block_wanted (block_wanted),
   .data_ready (data_ready),
   .reset_bmc_decoder (reset),
-  .avl_blocks_nb (avl_blocks_nb)
+  .avl_blocks_nb (avl_blocks_nb),
+  .state_led (state_led)
   );
 
 reg [23:0] tmp_counter = 0;

--- a/FPGA/triad_manager/triad_manager.v
+++ b/FPGA/triad_manager/triad_manager.v
@@ -7,6 +7,7 @@
 
 module triad_manager (
   input wire clk_96MHz,
+  input wire clk_72MHz,
 
   inout wire envelop_wire_0,
   inout wire envelop_wire_1,
@@ -27,6 +28,7 @@ module triad_manager (
 wire state_led1;
 wire state_led2;
 wire state_led3;
+wire state_led4;
 
 wire d_0_oe;
 wire d_0_out;
@@ -110,8 +112,8 @@ single_receiver_manager RECV0 (
   .data_output (d_0_out),
   .block_wanted (block_wanted_0),
   .data_ready (data_ready_0),
-  .avl_blocks_nb (avl_blocks_nb_0),
-  .state_led (state_led1)
+  .avl_blocks_nb (avl_blocks_nb_0)//,
+  //.state_led (state_led)
   );
 
 wire [7:0] block_wanted_number_1;
@@ -165,7 +167,7 @@ wire [16:0] polynomial;
 wire pulse_identifier_ready;
 
 pulse_identifier PULSE_IDENTIFIER0 (
-  .clk_96MHz (clk_96MHz),
+  .clk_72MHz (clk_72MHz),
   .block_wanted_0 (block_wanted_0),
   .block_wanted_1 (block_wanted_1),
   .block_wanted_2 (block_wanted_2),
@@ -184,8 +186,8 @@ pulse_identifier PULSE_IDENTIFIER0 (
   .block_wanted_number_0 (block_wanted_number_0),
   .block_wanted_number_1 (block_wanted_number_1),
   .block_wanted_number_2 (block_wanted_number_2),
-  .state_led (state_led),
-  .sys_ts (sys_ts)
+  .sys_ts (sys_ts),
+  .state_led (state_led)
   );
 
 reg [67:0] triad_data = 0;
@@ -202,7 +204,7 @@ data_parser PARSER0(
   .reset_pulse_identifier (reset_pulse_identifier)
   );
 
-always @ (posedge clk_96MHz) begin
+always @ (posedge clk_72MHz) begin
   if (pulse_identifier_ready) begin
     triad_data_avl <= 1;
     triad_data <= {
@@ -212,6 +214,14 @@ always @ (posedge clk_96MHz) begin
     triad_data_avl <= 0;
   end
 end
+
+reg [23:0] tmp_counter = 0;
+
+//assign state_led = tmp_counter[23];
+
+always @ (posedge clk_96MHz) begin
+  if (avl_blocks_nb_0 == 0) begin
+    tmp_counter <= tmp_counter + 1;
   end
 end
 

--- a/FPGA/triad_manager/triad_manager.v
+++ b/FPGA/triad_manager/triad_manager.v
@@ -21,14 +21,8 @@ module triad_manager (
   input wire reset_parser,
 
   output wire data_avl,
-  output wire [101:0] sensor_iterations,
-
-  output wire state_led
+  output wire [101:0] sensor_iterations
   );
-wire state_led1;
-wire state_led2;
-wire state_led3;
-wire state_led4;
 
 wire d_0_oe;
 wire d_0_out;
@@ -112,8 +106,7 @@ single_receiver_manager RECV0 (
   .data_output (d_0_out),
   .block_wanted (block_wanted_0),
   .data_ready (data_ready_0),
-  .avl_blocks_nb (avl_blocks_nb_0)//,
-  //.state_led (state_led)
+  .avl_blocks_nb (avl_blocks_nb_0)
   );
 
 wire [7:0] block_wanted_number_1;
@@ -134,8 +127,7 @@ single_receiver_manager RECV1 (
   .data_output (d_1_out),
   .block_wanted (block_wanted_1),
   .data_ready (data_ready_1),
-  .avl_blocks_nb (avl_blocks_nb_1),
-  .state_led (state_led2)
+  .avl_blocks_nb (avl_blocks_nb_1)
   );
 
 wire [7:0] block_wanted_number_2;
@@ -156,8 +148,7 @@ single_receiver_manager RECV2 (
   .data_output (d_2_out),
   .block_wanted (block_wanted_2),
   .data_ready (data_ready_2),
-  .avl_blocks_nb (avl_blocks_nb_2),
-  .state_led (state_led3)
+  .avl_blocks_nb (avl_blocks_nb_2)
   );
 
 wire [16:0] pulse_id_0;
@@ -186,8 +177,7 @@ pulse_identifier PULSE_IDENTIFIER0 (
   .block_wanted_number_0 (block_wanted_number_0),
   .block_wanted_number_1 (block_wanted_number_1),
   .block_wanted_number_2 (block_wanted_number_2),
-  .sys_ts (sys_ts),
-  .state_led (state_led)
+  .sys_ts (sys_ts)
   );
 
 reg [67:0] triad_data = 0;
@@ -212,16 +202,6 @@ always @ (posedge clk_72MHz) begin
     };
   end else begin
     triad_data_avl <= 0;
-  end
-end
-
-reg [23:0] tmp_counter = 0;
-
-//assign state_led = tmp_counter[23];
-
-always @ (posedge clk_96MHz) begin
-  if (avl_blocks_nb_0 == 0) begin
-    tmp_counter <= tmp_counter + 1;
   end
 end
 

--- a/FPGA/triad_manager/triad_manager_sim.v
+++ b/FPGA/triad_manager/triad_manager_sim.v
@@ -7,6 +7,7 @@
 
 module triad_manager_sim (
   input wire clk_96MHz,
+  input wire clk_72MHz,
 
   input wire envelop_wire_0,
   input wire envelop_wire_1,
@@ -130,7 +131,7 @@ wire [16:0] polynomial;
 wire pulse_identifier_ready;
 
 pulse_identifier #(.waiting_ticks_after_second_pulses(100)) PULSE_IDENTIFIER0 (
-  .clk_96MHz (clk_96MHz),
+  .clk_72MHz (clk_72MHz),
   .block_wanted_0 (block_wanted_0),
   .block_wanted_1 (block_wanted_1),
   .block_wanted_2 (block_wanted_2),
@@ -157,7 +158,7 @@ reg triad_data_avl = 0;
 wire reset_pulse_identifier;
 
 data_parser PARSER0(
-  .clk_96MHz (clk_96MHz),
+  .clk_72MHz (clk_72MHz),
   .triad_data (triad_data),
   .triad_data_avl (triad_data_avl),
   .reset_parser (reset_parser),


### PR DESCRIPTION
# Purpose of this PR

This PR contains this batch of fixes:
- Deadlock fix,
- New clock at 72 MHz for data analysis in order to pass the timing check,
- BMC_decoder analysis only if envelop is at a low state,
- Ram accessibility > 195 fix,
- Simulation update --> considering the 72 MHz clock.