### PR TITLE
µROS enemy tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ This is our solution for [Valve lighthouse 2.0](https://www.vive.com/fr/accessor
 Some documentation can be found in the changelog section below.
 
 # Changelog
+- µROS enemy tracker https://github.com/robotique-ecam/ViveTracker/pull/19
 - ROS2 package + geometry refinement https://github.com/robotique-ecam/ViveTracker/pull/18
 - FPGA 8 sensors strategy https://github.com/robotique-ecam/ViveTracker/pull/17
 - LH2 geometry https://github.com/robotique-ecam/ViveTracker/pull/16

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# ViveTracker
+This is our solution for [Valve lighthouse 2.0](https://www.vive.com/fr/accessory/base-station2/) open source tracking in the Robotics french cup 2022 context.
+Some documentation can be found in the changelog section below.
+
+# Changelog
+- ROS2 package + geometry refinement https://github.com/robotique-ecam/ViveTracker/pull/18
+- FPGA 8 sensors strategy https://github.com/robotique-ecam/ViveTracker/pull/17
+- LH2 geometry https://github.com/robotique-ecam/ViveTracker/pull/16
+- FPGA fixes batch https://github.com/robotique-ecam/ViveTracker/pull/15
+- FPGA data parser https://github.com/robotique-ecam/ViveTracker/pull/14
+- FPGA BMC_decoder V3 https://github.com/robotique-ecam/ViveTracker/pull/13
+- FPGA architecture refactoring https://github.com/robotique-ecam/ViveTracker/pull/12
+- ECP5 migration https://github.com/robotique-ecam/ViveTracker/pull/11
+- OOTX Analysis https://github.com/robotique-ecam/ViveTracker/pull/10
+- FPGA pulse_identifier https://github.com/robotique-ecam/ViveTracker/pull/9
+- FPGA offset_finder https://github.com/robotique-ecam/ViveTracker/pull/8
+- FPGA polynomial_finder https://github.com/robotique-ecam/ViveTracker/pull/7
+- FPGA Linear Feedback Shift Register https://github.com/robotique-ecam/ViveTracker/pull/6
+- FPGA bmc_decoder & serial_communication modules https://github.com/robotique-ecam/ViveTracker/pull/5
+- FPGA TS4231 configuration https://github.com/robotique-ecam/ViveTracker/pull/4
+- Polynomial identification https://github.com/robotique-ecam/ViveTracker/pull/3
+- LFSR analysis https://github.com/robotique-ecam/ViveTracker/pull/1

--- a/µROS/enemy_soft/app-colcon.meta
+++ b/µROS/enemy_soft/app-colcon.meta
@@ -1,0 +1,20 @@
+{
+    "names": {
+        "rmw_microxrcedds": {
+            "cmake-args": [
+                "-DRMW_UXRCE_MAX_NODES=1",
+                "-DRMW_UXRCE_MAX_PUBLISHERS=1",
+                "-DRMW_UXRCE_MAX_SUBSCRIPTIONS=0",
+                "-DRMW_UXRCE_MAX_SERVICES=0",
+                "-DRMW_UXRCE_MAX_CLIENTS=0",
+                "-DRMW_UXRCE_MAX_HISTORY=1",
+            ]
+        },
+        "microxrcedds_client": {
+            "cmake-args": [
+                "-DUCLIENT_MAX_SESSION_CONNECTION_ATTEMPTS=1000",
+                "-DUCLIENT_MIN_SESSION_CONNECTION_INTERVAL=1000",
+            ]
+        },
+    }
+}

--- a/µROS/enemy_soft/app.c
+++ b/µROS/enemy_soft/app.c
@@ -1,0 +1,242 @@
+#include <stdio.h>
+#include <unistd.h>
+
+#include <rcl/rcl.h>
+#include <rcl/error_handling.h>
+#include <lh_tracker_msgs/msg/l_htracker.h>
+
+
+#include <rclc/rclc.h>
+#include <rclc/executor.h>
+#include <time.h>
+
+#ifdef ESP_PLATFORM
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "driver/uart.h"
+#include "driver/gpio.h"
+#include "esp_log.h"
+#include "driver/gpio.h"
+#endif
+
+#define RCCHECK(fn) { rcl_ret_t temp_rc = fn; if((temp_rc != RCL_RET_OK)){printf("Failed status on line %d: %d. Aborting.\n",__LINE__,(int)temp_rc);vTaskDelete(NULL);}}
+#define RCSOFTCHECK(fn) { rcl_ret_t temp_rc = fn; if((temp_rc != RCL_RET_OK)){printf("Failed status on line %d: %d. Continuing.\n",__LINE__,(int)temp_rc);}}
+
+rcl_publisher_t publisher;
+uint8_t* data;
+static uint32_t first_iteration_list[8];
+static uint32_t second_iteration_list[8];
+static lh_tracker_msgs__msg__LHtracker lh_tracker_msg;
+static bool parsing;
+static bool msg_ready;
+static bool processing_calibration;
+static bool led_state;
+
+void timer_callback(rcl_timer_t * timer, int64_t last_call_time)
+{
+	RCLC_UNUSED(last_call_time);
+	if (timer != NULL) {
+		if (processing_calibration){
+			led_state = !led_state;
+			gpio_set_level(22, led_state);
+		}
+	}
+}
+
+static void rx_task(void *arg)
+{
+    while (1) {
+        const int rxBytes = uart_read_bytes(UART_NUM_0, data, 51, 1000 / portTICK_PERIOD_MS);
+
+        if (rxBytes == 51) {
+						if (data[0] == 0xff && data[1] == 0xff && data[2] == 0xff) {
+							parsing = true;
+							lh_tracker_msg.sensors_nb_recovered = 0;
+
+							first_iteration_list[0] = (int)( (data[3] << 16) | (data[4] << 8) | (data[5]) );
+							second_iteration_list[0] = (int)( (data[6] << 16) | (data[7] << 8) | (data[8]) );
+
+							first_iteration_list[1] = (int)( (data[9] << 16) | (data[10] << 8) | (data[11]) );
+							second_iteration_list[1] = (int)( (data[12] << 16) | (data[13] << 8) | (data[14]) );
+
+							first_iteration_list[2] = (int)( (data[15] << 16) | (data[16] << 8) | (data[17]) );
+							second_iteration_list[2] = (int)( (data[18] << 16) | (data[19] << 8) | (data[20]) );
+
+							first_iteration_list[3] = (int)( (data[21] << 16) | (data[22] << 8) | (data[23]) );
+							second_iteration_list[3] = (int)( (data[24] << 16) | (data[25] << 8) | (data[26]) );
+
+							first_iteration_list[4] = (int)( (data[27] << 16) | (data[28] << 8) | (data[29]) );
+							second_iteration_list[4] = (int)( (data[30] << 16) | (data[31] << 8) | (data[32]) );
+
+							first_iteration_list[5] = (int)( (data[33] << 16) | (data[34] << 8) | (data[35]) );
+							second_iteration_list[5] = (int)( (data[36] << 16) | (data[37] << 8) | (data[38]) );
+
+							first_iteration_list[6] = (int)( (data[39] << 16) | (data[40] << 8) | (data[41]) );
+							second_iteration_list[6] = (int)( (data[42] << 16) | (data[43] << 8) | (data[44]) );
+
+							first_iteration_list[7] = (int)( (data[45] << 16) | (data[46] << 8) | (data[47]) );
+							second_iteration_list[7] = (int)( (data[48] << 16) | (data[49] << 8) | (data[50]) );
+
+							for (uint8_t i = 0; i<8; i++){
+								if (first_iteration_list[i] != 0){
+									lh_tracker_msg.sensors_nb_recovered ++;
+									if (lh_tracker_msg.sensors_nb_recovered == 1) {
+										lh_tracker_msg.id_first_sensor = i;
+										lh_tracker_msg.first_sensor_first_iteration = first_iteration_list[i];
+										lh_tracker_msg.first_sensor_second_iteration = second_iteration_list[i];
+									} else if (lh_tracker_msg.sensors_nb_recovered == 2) {
+										lh_tracker_msg.id_second_sensor = i;
+										lh_tracker_msg.second_sensor_first_iteration = first_iteration_list[i];
+										lh_tracker_msg.second_sensor_second_iteration = second_iteration_list[i];
+									} else if (lh_tracker_msg.sensors_nb_recovered == 3) {
+										lh_tracker_msg.id_third_sensor = i;
+										lh_tracker_msg.third_sensor_first_iteration = first_iteration_list[i];
+										lh_tracker_msg.third_sensor_second_iteration = second_iteration_list[i];
+									} else if (lh_tracker_msg.sensors_nb_recovered == 4) {
+										lh_tracker_msg.id_fourth_sensor = i;
+										lh_tracker_msg.fourth_sensor_first_iteration = first_iteration_list[i];
+										lh_tracker_msg.fourth_sensor_second_iteration = second_iteration_list[i];
+									}
+								}
+							}
+							if (lh_tracker_msg.sensors_nb_recovered >= 2){
+								msg_ready = true;
+							}
+							parsing = false;
+						} else {
+							//not in sync
+						}
+        } else {
+					//unable to read the full msg
+				}
+    }
+    free(data);
+}
+
+void appMain(void * arg)
+{
+	rcl_allocator_t allocator = rcl_get_default_allocator();
+	rclc_support_t support;
+
+	gpio_config_t io_conf = {
+	  .intr_type = GPIO_INTR_DISABLE,
+	  .mode = GPIO_MODE_OUTPUT,
+	  .pin_bit_mask = (1ULL<<22),
+	  .pull_down_en = 0,
+	  .pull_up_en = 0
+	};
+  gpio_config(&io_conf);
+
+	io_conf.mode = GPIO_MODE_INPUT;
+	io_conf.pin_bit_mask = (1ULL<<23);
+	gpio_config(&io_conf);
+	led_state = false;
+	gpio_set_level(22, led_state);
+
+	// create init_options
+	RCCHECK(rclc_support_init(&support, 0, NULL, &allocator));
+
+	// create node
+	rcl_node_t node;
+	RCCHECK(rclc_node_init_default(&node, "first_enemy_lh_msgs", "", &support));
+
+	// create publisher
+	RCCHECK(rclc_publisher_init_default(
+		&publisher,
+		&node,
+		ROSIDL_GET_MSG_TYPE_SUPPORT(lh_tracker_msgs, msg, LHtracker),
+		"/first_enemy/lh_msgs"));
+
+	// create timer,
+	rcl_timer_t timer;
+	const unsigned int timer_timeout = 200;
+	RCCHECK(rclc_timer_init_default(
+		&timer,
+		&support,
+		RCL_MS_TO_NS(timer_timeout),
+		timer_callback));
+
+	// create executor
+	rclc_executor_t executor;
+	RCCHECK(rclc_executor_init(&executor, &support.context, 1, &allocator));
+	RCCHECK(rclc_executor_add_timer(&executor, &timer));
+
+	uart_config_t uart_config = {
+        .baud_rate = 1000000,
+        .data_bits = UART_DATA_8_BITS,
+        .parity    = UART_PARITY_DISABLE,
+        .stop_bits = UART_STOP_BITS_1,
+        .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
+        .source_clk = UART_SCLK_APB,
+    };
+
+	uart_driver_install(UART_NUM_0, 2*1024, 0, 0, NULL, 0);
+  uart_param_config(UART_NUM_0, &uart_config);
+	uart_set_pin(UART_NUM_0, 1, 3, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
+
+	data = (uint8_t*) malloc(51);
+	parsing = false;
+	msg_ready = false;
+	struct timespec ts;
+	struct timespec last_ts = {
+		.tv_sec = 0,
+		.tv_nsec = 0
+	};
+	uint32_t ns_diff_min = 1e8;
+
+	xTaskCreate(rx_task, "uart_rx_task", 1024*2, NULL, 1, NULL);
+
+	processing_calibration = false;
+	bool start_async_wait = false;
+	struct timespec wait_ts = {
+		.tv_sec = 0,
+		.tv_nsec = 0
+	};
+	uint16_t calibration_send_counter = 0;
+
+	while(1){
+		rclc_executor_spin_some(&executor, RCL_MS_TO_NS(100));
+		clock_gettime(CLOCK_REALTIME, &ts);
+
+		if (gpio_get_level(23) == 1) {
+			if (!processing_calibration) gpio_set_level(22, false);
+			if (!start_async_wait) {
+				start_async_wait = true;
+				wait_ts = ts;
+			} else if (ts.tv_sec - wait_ts.tv_sec > 2) {
+				processing_calibration = true;
+				calibration_send_counter = 0;
+				ns_diff_min = 0;
+				start_async_wait = false;
+			}
+		}
+		else {
+			if (!processing_calibration) {
+				start_async_wait = false;
+				gpio_set_level(22, true);
+			}
+		}
+
+		if (msg_ready && !parsing && abs(ts.tv_nsec-last_ts.tv_nsec)>ns_diff_min){
+			if (processing_calibration) {
+				lh_tracker_msg.sensors_nb_recovered = 8;
+				calibration_send_counter ++;
+				if (calibration_send_counter > 300){
+					ns_diff_min = 1e8;
+					processing_calibration = false;
+				}
+			}
+			lh_tracker_msg.header.stamp.sec = ts.tv_sec;
+			lh_tracker_msg.header.stamp.nanosec = ts.tv_nsec;
+			RCSOFTCHECK(rcl_publish(&publisher, &lh_tracker_msg, NULL));
+			msg_ready = false;
+			last_ts = ts;
+		}
+	}
+
+	// free resources
+	RCCHECK(rcl_publisher_fini(&publisher, &node))
+	RCCHECK(rcl_node_fini(&node))
+
+  	vTaskDelete(NULL);
+}


### PR DESCRIPTION
# Purpose of this PR

Our onboard tracker is great, but it's onboard and not on enemy. In order to track them, we need a wireless bridge between them and our robotic network. Bluetooth seems promising but not fun at all, implying the management of several Bluetooth connections simultaneously on assurancetourix, and that's a real challenge that require a lot more time than I can invest in this project.

Another way of doing so is to implement a server in assurancetourix that can receive tcp or udp request from anything connected to the network, avoiding the management of simultaneous connections. In fact, this is pretty much how µROS works. So let's implement µROS on a small ESP32 that can bridge data from FPGA directly into ROS !

# What has been done ? 

The choice of an esp32 was pretty fast, I got one on my desk when thinking of a way of doing it. I red a lot of documentations of how µROS works and finally decided to implement it on my esp32 by following [this tutorial](https://medium.com/@SameerT009/connect-esp32-to-ros2-foxy-5f06e0cc64df) describing the installation of espressif idf, µROS and the interface between them, pretty straight forward (except for a VCS bug which require a `git init` when trying to build µROS).

## Hardware

The ESP32 I used is the [WROMM32 one](https://www.amazon.fr/SP-Cow-ESP-32S-d%C3%A9veloppement-Bluetooth-d%C3%A9nergie/dp/B08CCYWZN3/ref=sr_1_4_sspa?__mk_fr_FR=%C3%85M%C3%85%C5%BD%C3%95%C3%91&keywords=esp32&qid=1651790290&sr=8-4-spons&psc=1&spLa=ZW5jcnlwdGVkUXVhbGlmaWVyPUExWDdXQkZLSUxXSUpHJmVuY3J5cHRlZElkPUEwNzExMDAwMTRIT1ZMU0kyUzVIWCZlbmNyeXB0ZWRBZElkPUEwMzIwNTMwRTUwSDZSN0Y3T1U1JndpZGdldE5hbWU9c3BfYXRmJmFjdGlvbj1jbGlja1JlZGlyZWN0JmRvTm90TG9nQ2xpY2s9dHJ1ZQ==).

Pinout:
- RX0 connected to pin J17 (UART TX) of the FPGA,
- Button with pull down on the pin D23 (low state when the button isn't pressed),
- LED on pin D22 (LED on when D22 at low_state).

## Software

In fact, it's almost the exact same as [lh_tracker_serial node](https://github.com/robotique-ecam/ViveTracker/blob/30e6414308297a92c665959910591267d0fd6818/ros2_node/lh_tracker/lh_tracker_serial/lh_tracker_serial_node.py).

The goal is to parse the flow of data from FPGA into an [LHtracker](https://github.com/robotique-ecam/ViveTracker/blob/30e6414308297a92c665959910591267d0fd6818/ros2_node/lh_tracker_msgs/msg/LHtracker.msg) message type and publish it on a topic (here `"/first_enemy/lh_msgs"`).


**An enemy tracker will be used for initial transformation computing.** To enter calibration mode, press the button for at least 3 seconds, the led will start to blink for 300 transmissions, only 200 are required for a full calibration, but for safety reasons, 300 are sent.

Here's the initialization sequence:
- Plug it,
- The [led will be on during power-up sequence](https://github.com/robotique-ecam/ViveTracker/blob/95ed0d331c8d839de45ac6507adf1fdfdf39df3e/%C2%B5ROS/enemy_soft/app.c#L134),
- When the [led is off](https://github.com/robotique-ecam/ViveTracker/blob/95ed0d331c8d839de45ac6507adf1fdfdf39df3e/%C2%B5ROS/enemy_soft/app.c#L216), it means that the esp successfully initializes itself (wifi and ros synchronization),
- Plug the FPGA,
- Initialize all sensors (each sensor must have receive a direct sweep at least once for initialization),
- If the transformation of the lighthouse hasn't been computed:
  - Place the tracker at the calibration coordinates and orientation,
  - [Push the button at least 3 seconds](https://github.com/robotique-ecam/ViveTracker/blob/95ed0d331c8d839de45ac6507adf1fdfdf39df3e/%C2%B5ROS/enemy_soft/app.c#L206) until the led starts blinking,
  - When the led stops, the initialization sequence is done.

In order to reduce network saturation, the LHtracker message is slowed down to [10Hz](https://github.com/robotique-ecam/ViveTracker/blob/95ed0d331c8d839de45ac6507adf1fdfdf39df3e/%C2%B5ROS/enemy_soft/app.c#L225) (except for calibration which is [50Hz](https://github.com/robotique-ecam/ViveTracker/blob/95ed0d331c8d839de45ac6507adf1fdfdf39df3e/%C2%B5ROS/enemy_soft/app.c#L209)).

## Build instructions

µROS needs building instruction ([here](https://github.com/robotique-ecam/ViveTracker/blob/95ed0d331c8d839de45ac6507adf1fdfdf39df3e/%C2%B5ROS/enemy_soft/app-colcon.meta)) indicating what contains this node. It also contains the number of ROS connection trial before crashing.

## Assurancetourix bridge

Assurancetourix will need to launch a ros2 node in order to bridge µROS and ROS on the same network:
```
ros2 run micro_ros_agent micro_ros_agent udp4 --port 8888
```